### PR TITLE
Moar traits

### DIFF
--- a/index.html
+++ b/index.html
@@ -1658,7 +1658,8 @@
                   and receive half healing from all sources. You do not die when you are reduced to 0 HP 
                   and you instead fall <a class="condition" data-tooltip-container>unconscious</a>. You can then only be woken by
                   healing. This healing may partially reconstruct the creature's body if 
-                  the detached or broken pieces are nearby.
+                  the detached or broken pieces are nearby, however missing limbs don't regrow and if there is major desecration 
+                  you will not be able to be reanimated.
                </td>
                <td>
                </td>

--- a/index.html
+++ b/index.html
@@ -1692,20 +1692,6 @@
                </td>
             </tr>
             <tr>
-               <td>Spectral Hand
-               </td>
-               <td>
-                  You may create a spectral hand that can float, move, and mimics your own hand within
-                  25ft. It has an AC of 14, Light HP, no resistance points, a STR value of 2 (-4 modifier), and a 
-                  base movement speed of 5ft. You can make INT+DEX checks to perform more challenging dexterous 
-                  actions with the hand using your own modifiers. The hand persists for 6 seconds before disappearing.
-               </td>
-               <td>1 AP - 3 Uses
-               </td>
-               <td>Arcane Level 1
-               </td>
-            </tr>
-            <tr>
                <td>Arcane Repair
                </td>
                <td>
@@ -1730,6 +1716,20 @@
                <td>1 AP - 3 Uses
                </td>
                <td>Arcane Level 1
+               </td>
+            </tr>
+            <tr>
+               <td>Spectral Hand
+               </td>
+               <td>
+                  You may create a spectral hand that can float, move, and mimics your own hand within
+                  25ft. It has an AC of 14, Light HP, no resistance points, a STR value of 2 (-4 modifier), and a 
+                  base movement speed of 5ft. You can make INT+DEX checks to perform more challenging dexterous 
+                  actions with the hand using your own modifiers. The hand persists for 6 seconds before disappearing.
+               </td>
+               <td>1 AP - 3 Uses
+               </td>
+               <td>Arcane Level 3
                </td>
             </tr>
             <tr>
@@ -1914,6 +1914,31 @@
                </td>
             </tr>
             <tr>
+               <td>Create Vision
+               </td>
+               <td>
+                  You may touch a creature to make them see a vivid vision of your choosing.  This can persist as long as you remain in contact 
+                  with the creature.  They are free to move away and are aware of the source of the vision.
+               </td>
+               <td>1 AP - 3 Uses
+               </td>
+               <td>Psionic Level 3
+               </td>
+            </tr>
+            <tr>
+               <td>Detect Thoughts
+               </td>
+               <td>
+                  You may sense intelligent creatures in a 20ft radius as spots of light when you close your eyes.
+                  Creatures have to have an intelligence of at least 8 for you to be able to see them, and the more intelligent
+                  the creature, the brighter the spots of light.
+               </td>
+               <td>2 AP - 3 Uses
+               </td>
+               <td>Psionic Level 3
+               </td>
+            </tr>
+            <tr>
                <td>Disguise Self
                </td>
                <td>
@@ -1976,18 +2001,19 @@
                </td>
             </tr>
             <tr>
-               <td>Modify Memory
+               <td>Occupy
                </td>
                <td>
-                  You may modify any 10 minutes of memory from a creature from the last week. The change in memory lasts
-                  until their next long rest - at which point they do not realise they have been
-                  affected. 2 WILL points to resist. If they successfully resist the effect the target creature will be 
-                  aware something tried to control their thoughts, but will not know the source unless you cast the 
-                  ability right in front of them or they are very knowledgeable in psionic magic.
+                  You may touch a creature to occupy it's head. You see through it's eyes and can communicate with it via thoughts.
+                  While this is happening are and are <a class="condition" data-tooltip-container>immobilised</a> and only slightly 
+                  aware of your surrondings.  You can influence this creature, giving it either adv (+) or dis (-) on each of its skill 
+                  checks.  You can end this at any time and it automatically ends if you take damage.
+
+                  2 WILL resist, and a further 1 WILL resist check every 5 minutes.
                </td>
                <td>3 AP - 3 Uses
                </td>
-               <td>Psionic Level 10
+               <td>Psionic Level 7
                </td>
             </tr>
             <tr>
@@ -1998,6 +2024,21 @@
                   desires. You learn whatever primary motivations they might have - if any. 
                   GM's discretion as to how specifically these are described. 2 WILL
                   points to resist. If they successfully resist the effect the target creature will be 
+                  aware something tried to control their thoughts, but will not know the source unless you cast the 
+                  ability right in front of them or they are very knowledgeable in psionic magic.
+               </td>
+               <td>3 AP - 3 Uses
+               </td>
+               <td>Psionic Level 7
+               </td>
+            </tr>
+            <tr>
+               <td>Modify Memory
+               </td>
+               <td>
+                  You may modify any 10 minutes of memory from a creature from the last week. The change in memory lasts
+                  until their next long rest - at which point they do not realise they have been
+                  affected. 2 WILL points to resist. If they successfully resist the effect the target creature will be 
                   aware something tried to control their thoughts, but will not know the source unless you cast the 
                   ability right in front of them or they are very knowledgeable in psionic magic.
                </td>
@@ -2021,6 +2062,22 @@
                   than 100ft from it at any time. 
                </td>
                <td>1 AP - 3 Uses
+               </td>
+               <td>Psionic Level 10
+               </td>
+            </tr>
+            <tr>
+               <td>Memory Walk
+               </td>
+               <td>
+                  You may touch a creature to walk through it's mind, glimpsing memories of its past. 
+                  You can direct what you see by asking to recall specific events.
+                  You and the creature are <a class="condition" data-tooltip-container>immobilised</a>
+                  for the duration of this trait.  You are free to end this at any time.
+
+                  2 WILL resist, and a further 1 WILL resist check every 6 seconds.
+               </td>
+               <td>3 AP - 3 Uses
                </td>
                <td>Psionic Level 10
                </td>
@@ -2053,23 +2110,10 @@
                </td>
             </tr>
             <tr>
-               <td>Clean water
+               <td>Clean Water
                </td>
                <td>
                   You may convert a cup of muddy, undrinkable water into clean drinking water.
-               </td>
-               <td>1 AP - No Use Limit
-               </td>
-               <td>Nature Level 1 or Mortality level 1
-               </td>
-            </tr>
-            <tr>
-               <td>Decompose
-               </td>
-               <td>
-                  You gain the ability to touch and decompose a dead creature, causing it to rot
-                  and sprout maggots. The longer you spend on the spell, the more complete the
-                  decomposition. You can entirely decompose a body in approximately 5 minutes.
                </td>
                <td>1 AP - No Use Limit
                </td>
@@ -2100,6 +2144,19 @@
                <td>3 AP - 3 Uses
                </td>
                <td>Nature Level 1
+               </td>
+            </tr>
+            <tr>
+               <td>Decompose
+               </td>
+               <td>
+                  You gain the ability to touch and decompose a dead creature, causing it to rot
+                  and sprout maggots. The longer you spend on the spell, the more complete the
+                  decomposition. You can entirely decompose a body in approximately 5 minutes.
+               </td>
+               <td>1 AP - No Use Limit
+               </td>
+               <td>Nature Level 3 or Mortality level 3
                </td>
             </tr>
             <tr>
@@ -2151,7 +2208,7 @@
                </td>
             </tr>
             <tr>
-               <td>Clean water
+               <td>Clean Water
                </td>
                <td>
                   You may convert a cup of muddy, undrinkable water into clean drinking water.
@@ -2171,11 +2228,23 @@
                </td>
                <td>1 AP - No Use Limit
                </td>
-               <td>Nature Level 1 or Mortality level 1
+               <td>Nature Level 3 or Mortality level 3
                </td>
             </tr>
             <tr>
-               <td>Speak With Dead
+               <td>Detect Life
+               </td>
+               <td>
+                  You may sense living creatures in a 15ft radius as spots of soul energy when you close your eyes
+                  The larger the creature, the larger and brighter the the spots are.
+               </td>
+               <td>2 AP - 3 Uses
+               </td>
+               <td>Mortality Level 3
+               </td>
+            </tr>
+            <tr>
+               <td>Speak with Dead
                </td>
                <td>
                   You may talk to a single dead creature within 25ft for up to 10 minutes. 
@@ -2256,7 +2325,7 @@
                </td>
                <td>1 AP - No Use Limit
                </td>
-               <td>Elemental Level 3
+               <td>Elemental Level 1
                </td>
             </tr>
             <tr>
@@ -2268,7 +2337,44 @@
                </td>
                <td>3 AP - no use limit
                </td>
-               <td>Elemental Level 5
+               <td>Elemental Level 3
+               </td>
+            </tr>
+            <tr>
+               <td>Elemental Aspect
+               </td>
+               <td>
+                  When you use non-magical weapons you can channel elemental energy, causing them to deal 
+                  either fire, frost, or lightning damage instead of physical.  You can only 
+                  select one type of damage when taking this trait.
+
+                  You can take this trait multiple times to unlock the other types of damage.
+               </td>
+               <td>
+               </td>
+               <td>Elemental Level 3
+               </td>
+            </tr>
+            <tr>
+               <td>Elemental Weapons
+               </td>
+               <td>
+                  You can summon an weapon made out of elemental energy, causing them to deal 
+                  either fire, frost, or lightning damage instead of physical.  You can only 
+                  select one type of damage when taking this trait.  These are still wielded
+                  using the rules of their physical couterparts - e.g. STR is used for a heavy
+                  weapon.
+
+                  You can take this trait multiple times to unlock the other types of damage.
+
+                  You can dismiss this at any time, and the weapon disappears when you let go of it, 
+                  rest, or are <a class="condition" data-tooltip-container>silenced</a> or
+                  <a class="condition" data-tooltip-container>unconscious</a>.
+               </td>
+               <td>
+                  1 AP - Unlimited uses
+               </td>
+               <td>Elemental Level 3
                </td>
             </tr>
             </table>
@@ -2305,6 +2411,22 @@
                      if the item/material is more complex.
                   </td>
                   <td>3 AP - No Use Limit
+                  </td>
+                  <td>Engineer Level 1
+                  </td>
+               </tr>
+               <tr>
+                  <td>Alarm
+                  </td>
+                  <td>
+                     You may place a tripwire across 15ft.  When these are crossed by a creature, 
+                     you are aware they've been set off and the size of the creature which triggered them.
+                     This wakes you up if during a long rest, and they persist until you deconstruct them,
+                     they are triggered, or till the end of a long rest.
+
+                     These can be bypassed by a creature which is intelligent and perceptive enough.
+                  </td>
+                  <td>1 AP - 3 Uses
                   </td>
                   <td>Engineer Level 1
                   </td>

--- a/index.html
+++ b/index.html
@@ -1181,7 +1181,7 @@
             <tr>
                <td>Music
                </td>
-               <td>A Particular Instrument
+               <td>Religion
                </td>
                <td>Dancing
                </td>
@@ -1254,14 +1254,10 @@
          <h4 id="Traits">Traits</h4>
          <p>
             Traits are special abilities that can be found in the trait tables below. They
-            are often non-combat abilities that add flavour and utility to a character or
+            are primarily non-combat abilities that add flavour and utility to a character or
             creature. Some also have specified requirements that a character must meet to be
             able to unlock the trait. Some are passive, while others are limited to 1 or 3
             uses.
-         </p>
-         <p>
-            TODO: Traits are unfinished and many of them need tweaking and reworking. You
-            should discuss with your GM which traits they are comfortable letting you have.
          </p>
          <h5 id="General Traits">General Traits</h5>
          <table class="center">
@@ -1450,9 +1446,12 @@
                <td>Muscian
                </td>
                <td>
-                  You learn a how to play a new musical instrument (can be taken multiple times).
-
+                  You learn how to play a musical instrument and gain Adv (++) 
+                  on all skill checks to play this instrument (can be taken multiple times). 
                   This also gives you advantage (+) on checks on similar instruments.
+
+                  You can then take a skill in the same instrument to raise the level of Adv from 
+                  (++) to (+++).
                </td>
                <td>
                   Passive
@@ -1489,7 +1488,7 @@
                <td>Test for Poison
                </td>
                <td>
-                  You can check food, drink, and affected creatures for signs of poisons. 
+                  You may check food, drink, and affected creatures for signs of poisons. 
                   This tells you what poison has been used and what the cure might be.
                </td>
                <td>
@@ -1752,13 +1751,14 @@
                <td>Spectral Object
                </td>
                <td>
-                  You may create a spectral object that occupies up to a 5*5*5ft cube.  This object is solid, 
-                  takes a form of your desire (e.g. chair, ramp, barricade), and can support a weight of up to 200kg
-                  without breaking.  It has an AC of 6 and Light HP.
+                  You may create a spectral object within 5ft that occupies up to a 5*5*5ft cube. This object is solid and  
+                  takes a form of your desire (e.g. chair, ramp, barricade). You may decide whether the object is moveable 
+                  or not: if moveable it will weigh around 1kg, ; if not moveable it will exist solidly floating in space and 
+                  can support a weight of 200kg before breaking. It has an AC of 6 and Light HP.
                   
                   You can dismiss this at any time for 0AP, and it persists till the end of your next long rest.
                </td>
-               <td>1 AP - 3 Uses
+               <td>1 Minute - 3 Uses
                </td>
                <td>Arcane Level 3
                </td>
@@ -1767,7 +1767,7 @@
                <td>Create Sanctuary
                </td>
                <td>
-                  You may take 10 minutes to create a sanctuary in a 10ft radius which only creatures you choose may enter. 
+                  You may take 10 minutes to create a sanctuary around yourself in a 10ft radius which only creatures you choose may enter. 
                   Within it maintains a comfortable temperature, a dim source of ambient light, and 
                   shields all within from bad weather such as rain wind and snow. Creatures may spend 4 WILL 
                   points to force their way into the sanctuary if they have not been permitted entry.
@@ -1781,7 +1781,7 @@
                <td>Identify
                </td>
                <td>
-                  You may touch and identify the specific nature and capability of a magical object or area.
+                  You may touch and identify the specific nature and capability of a magical object or area within 5ft.
                   This might include learning all of the magical properties of an enchanted item or weapon, 
                   or learning all of the magical effects that affect the area you are specifically and 
                   currently stood in. In very rare cases, some objects or areas may still remain unidentifiable.
@@ -1795,7 +1795,7 @@
                <td>Lesser Dispel Magic
                </td>
                <td>
-                  You may dispel the magic properties from a lesser magical item or area of weak magic. 
+                  You may dispel the magic properties from a lesser magical item or area of weak magic within 5ft. 
                   This might include a lesser magical scroll or potion, a very simple weapon enchantment, 
                   a lesser magical trap or rune, or an area cursed or empowered by a weak source of magic. 
                   The specific capabilities of this ability will be up to the GM's discretion.
@@ -1852,7 +1852,7 @@
                   is not a part of the Arcus lore but GM's may still wish to use it for other 
                   campaigns.
                   <p>
-                  You may dispel the magic properties from a greater magical item or area of stronger magic. 
+                  You may dispel the magic properties from a greater magical item or area of stronger magic within 5ft. 
                   This might include most magical scroll or potion, a more complex weapon enchantment, 
                   most magical traps or runes, or most areas cursed or empowered by a stronger source of magic. 
                   The specific capabilities of this ability will be up to the GM's discretion.
@@ -1936,8 +1936,8 @@
                <td>Telekinesis
                </td>
                <td>
-                  You gain the ability to move small objects with your mind at will (up to 1kg
-                  at a rate of 5ft per AP - 15ft total movement per use).
+                  You gain the ability to move small objects (up to 1kg) within 50ft
+                  at a rate of 5ft per AP (up to 15ft total movement per use).
                </td>
                <td>3 AP - 3 Uses
                </td>
@@ -1960,7 +1960,8 @@
                <td>Detect Thoughts
                </td>
                <td>
-                  You may sense intelligent creatures in a 15ft radius as spots of light when you close your eyes.
+                  You may sense intelligent creatures in a 15ft radius as spots of light when you close your eyes. 
+                  This includes seeing them through walls. This vision persists for 6 seconds.
                   Creatures have to have an intelligence of at least 8 for you to be able to see them, and the more intelligent
                   the creature, the brighter the spots of light.
                </td>
@@ -2008,7 +2009,7 @@
                   You may become <a class="condition" data-tooltip-container>invisible</a> for 10 minutes. You can use this on a willing ally
                   within 25ft but the effect will only last 1 minute.
                </td>
-               <td>2 AP - 1 Use
+               <td>3 AP - 3 Uses
                </td>
                <td>Psionic Level 5
                </td>
@@ -2035,7 +2036,7 @@
                <td>Occupy
                </td>
                <td>
-                  You may touch a creature to occupy it's head. You share its senses and can communicate with it via thoughts.
+                  You may touch a creature to occupy it's head. You share its senses and can communicate back and forth with it via thoughts.
                   While this is happening are and are <a class="condition" data-tooltip-container>paralysed</a> and only slightly 
                   aware of your surrondings. You can end this at any time and it automatically ends if you (not the creature) take
                   damage.
@@ -2106,7 +2107,8 @@
                   be imperfect, hazy, or nonexistant.   
                   You and the creature are <a class="condition" data-tooltip-container>paralysed</a>
                   and <a class="condition" data-tooltip-container>blind</a>
-                  for the duration of this trait.  You are free to end this at any time.
+                  for the duration of this trait.  You are free to end this at any time. The effect also 
+                  ends if either of you suffer damage during this effect.
 
                   2 WILL resist, and a further 1 WILL resist check every 6 seconds.  
                   This can last up to 1 minute.  
@@ -2199,7 +2201,7 @@
                </td>
                <td>
                   you may grant any number of willing creatures within 25ft the ability to climb at
-                  full speed with advantage (+) on their skill check. This lasts 10 minutes.
+                  full speed with advantage (+) on their skill check. This lasts 1 minute.
                </td>
                <td>3 AP - 3 Uses
                </td>
@@ -2211,7 +2213,7 @@
                </td>
                <td>
                   You may grant any number of willing creatures within 25ft the ability to swim at
-                  full speed with advantage (+) on their skill check. This lasts 10 minutes.
+                  full speed with advantage (+) on their skill check. This lasts 1 minute.
                </td>
                <td>3 AP - 3 Uses
                </td>
@@ -2273,6 +2275,7 @@
                <td>
                   You may sense living creatures in a 10ft radius as spots of soul energy when you close your eyes
                   The larger the creature, the larger and brighter the the spots are.
+                  This includes seeing them through walls. This vision persists for 6 seconds.
                </td>
                <td>1 Minute - 1 Use
                </td>
@@ -2298,10 +2301,11 @@
                <td>True Resurrection
                </td>
                <td>
-                  You may choose a willing creature within 25ft that has died in the past hour and bring it
+                  You may select a willing creature within 25ft that has died in the past hour and bring it
                   back to life. You choose how much HP to give it by spending from your own
-                  current pool of HP. This is not without consequences, the corpse must not be
-                  desecrated and any missing limbs do not regrow. The creature has DisAdv (---) on
+                  current pool of HP, and this healing may partially reconstruct the creature's body if the detached or 
+                  broken pieces are nearby, however missing limbs don't regrow and if there is major desecration 
+                  you will not be able to be reanimated. The creature has DisAdv (---) on
                   all of it’s rolls until it takes a long rest.
                </td>
                <td>3 AP - 1 Use
@@ -2313,10 +2317,11 @@
                <td>True Necromancy
                </td>
                <td>
-                  You may choose a creature within 25ft that has died at any time and bring it
+                  You may select a creature within 25ft that has died at any time and bring it
                   back as an undead. You choose how much HP to give it by spending from your own
                   current pool of HP, and this healing may partially reconstruct the creature's body if the detached or 
-                  broken pieces are nearby. The creature has DisAdv (---) on all of it’s rolls until it 
+                  broken pieces are nearby, however missing limbs don't regrow and if there is major desecration 
+                  you will not be able to be reanimated. The creature has DisAdv (---) on all of it’s rolls until it 
                   takes a long rest. The creature also gains the Undead trait permanently.
                </td>
                <td>3 AP - 1 Use
@@ -2380,9 +2385,10 @@
                <td>Unnatural Wind
                </td>
                <td>
-                  You may create a strong wind in any direction in an area within 25ft.  
+                  You may create a strong wind in any direction in an area within 25ft. This has a limited 
+                  capability to push objects, up to around 1kg.
                </td>
-               <td>3 AP - 1 Use
+               <td>3 AP - 3 Uses
                </td>
                <td>Elemental Level 3
                </td>
@@ -2395,16 +2401,16 @@
                   or coating an existing weapon with the elemental of your choice for 1AP. This causes them to deal 
                   either fire, frost, or lightning damage instead of the weapon's normal damage type.  
                   You can only select one type of damage when taking this trait.  These are still wielded
-                  using the modifiers (STR or DEX) of their normal counterparts.  
+                  using the modifiers (STR or DEX) of their physical counterparts.  
 
                   You can take this trait multiple times to unlock the other types of damage.
 
-                  You can dismiss this at any time, and the element disappears when you let go of it, 
+                  You can dismiss this at any time, and the elemental effect ends when you let go of the weapon, 
                   rest, are <a class="condition" data-tooltip-container>silenced</a> or
                   <a class="condition" data-tooltip-container>unconscious</a>.
                </td>
                <td>
-                  1 AP - Unlimited uses
+                  1 AP - No Use Limit
                </td>
                <td>Elemental Level 3
                </td>
@@ -2441,7 +2447,8 @@
                   <td>
                      You may repair a damaged non magical object. You can repair approximately 
                      1 cubic foot of material per minute of using this ability, though this will be longer 
-                     if the item/material is more complex.
+                     if the item/material is more complex, and you will require the physical materials and tools
+                     necessary to repair the object. 
                   </td>
                   <td>3 AP - No Use Limit
                   </td>
@@ -2452,14 +2459,14 @@
                   <td>Alarm
                   </td>
                   <td>
-                     You may place a tripwire across 15ft.  When these are crossed by a creature, 
-                     you are aware they've been set off and the size of the creature which triggered them
-                     or they create a loud noise, your choice.
-                     This wakes you up if during a long rest, and they persist until you deconstruct them,
-                     they are triggered, or till the end of a long rest.
+                     You may place a 15ft long tripwire between 2 points.  When this wire is touched without being disarmed, 
+                     you are aware it has been set off and the size of the creature/object which triggered it. You may also
+                     have the tripwire then create a loud noise at the location of the tripwire.
+                     This will wake you up if it occurs during a long rest, and it persists until you deconstruct them,
+                     they are triggered, or until the end of a long rest.
 
-                     These can be spotted by a creature who's Passive Perception passes your INT value,
-                     and disarmed by a creature with an INT+DEX check with a DC of your INT value.
+                     The tripwire can be spotted by a creature with a passive perception value or a PER+PER roll greater than your INT value.
+                     It can also be disarmed by a creature with an INT+DEX roll greater than your INT value.
                   </td>
                   <td>1 AP - 3 Uses
                   </td>
@@ -2470,7 +2477,7 @@
                   <td>Windup Toy
                   </td>
                   <td>
-                     You may place a small wind up toy that runs forward up to 30ft, creating a simple
+                     You may place a 0.5ft tall wind up toy that moves forward up to 30ft, creating a simple
                      noise of your choice.  
 
                      If you recover your toy, you can reuse it without having to make another over a long rest.

--- a/index.html
+++ b/index.html
@@ -1270,7 +1270,7 @@
                </td>
                <td><strong>Desc</strong>
                </td>
-               <td><strong>Notes</strong>
+               <td><strong>Usage</strong>
                </td>
                <td><strong>Requirements</strong>
                </td>
@@ -1282,6 +1282,7 @@
                   You may remove the -2 to attack rolls made when attacking with a Medium and Light weapon.
                </td>
                <td>
+                  Passive
                </td>
                <td>None
                </td>
@@ -1294,6 +1295,7 @@
                   off-hand.
                </td>
                <td>
+                  Passive
                </td>
                <td>None
                </td>
@@ -1305,6 +1307,7 @@
                   You can add your modifier to damage on unarmed attacks.
                </td>
                <td>
+                  Passive
                </td>
                <td>None
                </td>
@@ -1317,6 +1320,7 @@
                   However, this climbing will still require a skill check in most cases.
                </td>
                <td>
+                  Passive
                </td>
                <td>None
                </td>
@@ -1329,6 +1333,7 @@
                   However, this swimming will still require a skill check in some cases.
                </td>
                <td>
+                  Passive
                </td>
                <td>None
                </td>
@@ -1340,6 +1345,7 @@
                   Attacks you make while mounted are no longer made with DisAdv (-).
                </td>
                <td>
+                  Passive
                </td>
                <td>None
                </td>
@@ -1353,6 +1359,7 @@
                   any kind.
                </td>
                <td>
+                  Once per short rest.
                </td>
                <td>None
                </td>
@@ -1366,6 +1373,7 @@
                   short rest. You can also apply a disguise to another willing creature.
                </td>
                <td>
+                  30 minutes - No use limit.
                </td>
                <td>None
                </td>
@@ -1380,6 +1388,7 @@
                   up to GM's discretion.
                </td>
                <td>
+                  Passive
                </td>
                <td>None
                </td>
@@ -1393,6 +1402,7 @@
                   checks to sneak or <a class="condition" data-tooltip-container>hide</a> that are affected by vision. This can be done during a short rest.
                </td>
                <td>
+                  30 minutes - no use limit.
                </td>
                <td>Master of Disguise or Global Level 5
                </td>
@@ -1406,6 +1416,7 @@
                   40ft would be 10, 65ft would be 40 etc.
                </td>
                <td>
+                  Passive
                </td>
                <td>None
                </td>
@@ -1418,6 +1429,7 @@
                   any attribute that is already 18 or higher.
                </td>
                <td>
+                  Passive
                </td>
                <td>3 Levels in a Physical Class and 3 Levels in a Magical Class
                </td>
@@ -1429,6 +1441,7 @@
                   You learn a new language (can be taken multiple times).
                </td>
                <td>
+                  Passive
                </td>
                <td>None
                </td>
@@ -1440,6 +1453,7 @@
                   You have very good recall of visual memory and your passive perception is increased by 6.
                </td>
                <td>
+                  Passive
                </td>
                <td>None
                </td>
@@ -1448,10 +1462,11 @@
                <td>Field Medic
                </td>
                <td>
-                  When taking a short rest, you may instead heal a creature for 1/4 of you HP rounded down 
+                  When taking a short rest, you may instead heal a creature for 1/4 of your HP rounded down 
                   instead of healing yourself for that amount.
                </td>
                <td>
+                  Once per short rest
                </td>
                <td>None
                </td>
@@ -1473,23 +1488,12 @@
                <td>Purity of Body
                </td>
                <td>
-                  When you take a short rest you can regain 5 resistance points of your choice instead of healing.
+                  When you take a short rest you no longer heal, and instead regain 5 resistance points of your choosing.
                </td>
                <td>
+                  Passive
                </td>
-               <td>Global Level 3
-               </td>
-            </tr>
-            <tr>
-               <td>Purity of Mind
-               </td>
-               <td>
-                  You can spend 5 resistance points of your choice to gain another 3AP this turn.
-               </td>
-               <td>
-                  1 AP, 1 Use.
-               </td>
-               <td>Global Level 10
+               <td>Global Level 3 - Cannot be taken with Field Medic.
                </td>
             </tr>
             <tr>
@@ -1528,7 +1532,7 @@
                </td>
                <td><strong>Desc</strong>
                </td>
-               <td><strong>Notes</strong>
+               <td><strong>Usage</strong>
                </td>
                <td><strong>Requirements</strong>
                </td>
@@ -1542,6 +1546,7 @@
                   long and why you have a higher life expectancy.
                </td>
                <td>
+                  Passive
                </td>
                <td>Suitable Ancenstry
                </td>
@@ -1553,6 +1558,7 @@
                   You may breathe underwater.
                </td>
                <td>
+                  Passive
                </td>
                <td>Suitable Ancenstry
                </td>
@@ -1564,6 +1570,7 @@
                   Damage you deal from unarmed attacks may be dealt as poison damage instead.
                </td>
                <td>
+                  Passive
                </td>
                <td>Suitable Ancenstry
                </td>
@@ -1578,6 +1585,7 @@
                   of water a day.
                </td>
                <td>
+                  Passive
                </td>
                <td>Suitable Ancenstry
                </td>
@@ -1595,6 +1603,7 @@
                   same amount. You cannot have negative resistance points.
                </td>
                <td>
+                  Passive
                </td>
                <td>Max size 1ft in the largest dimension
                </td>
@@ -1612,6 +1621,7 @@
                   same amount. You cannot have negative resistance points.
                </td>
                <td>
+                  Passive
                </td>
                <td>Max size 3ft in the largest dimension
                </td>
@@ -1629,6 +1639,7 @@
                   same amount. You cannot have negative resistance points.
                </td>
                <td>
+                  Passive
                </td>
                <td>At least 9ft in one dimension
                </td>
@@ -1647,6 +1658,7 @@
                   same amount. You cannot have negative resistance points.
                </td>
                <td>
+                  Passive
                </td>
                <td>At least 14ft in one dimension
                </td>
@@ -1663,6 +1675,7 @@
                   you will not be able to be reanimated.
                </td>
                <td>
+                  Passive
                </td>
                <td>None
                </td>
@@ -1675,7 +1688,7 @@
                </td>
                <td><strong>Desc</strong>
                </td>
-               <td><strong>Notes</strong>
+               <td><strong>Usage</strong>
                </td>
                <td><strong>Requirements</strong>
                </td>
@@ -1745,7 +1758,7 @@
                   shields all within from bad weather such as rain wind and snow. Creatures may spend 4 WILL 
                   points to force their way into the sanctuary if they have not been permitted entry.
                </td>
-               <td>1 Use
+               <td>10 Minutes - 1 Use
                </td>
                <td>Arcane Level 5
                </td>
@@ -1812,7 +1825,7 @@
                   skipping the creation step. Using this ability in this way only takes 3 AP (6 seconds) to cast.
                   </p>
                </td>
-               <td>1 Use
+               <td>1 Hour - 1 Use
                </td>
                <td>Arcane Level 10
                </td>
@@ -1831,7 +1844,7 @@
                   The specific capabilities of this ability will be up to the GM's discretion.
                   </p>
                </td>
-               <td>3 AP - 3 Uses
+               <td>3 AP - 1 Use
                </td>
                <td>Arcane Level 10
                </td>
@@ -1858,7 +1871,7 @@
                </td>
                <td><strong>Desc</strong>
                </td>
-               <td><strong>Notes</strong>
+               <td><strong>Usage</strong>
                </td>
                <td><strong>Requirements</strong>
                </td>
@@ -1900,7 +1913,7 @@
                   50ft. They must still understand the language you communicate in. They cannot 
                   respond telepathically, only you may communicate to them.
                </td>
-               <td>No Use Limit
+               <td>Passive
                </td>
                <td>Psionic Level 1
                </td>
@@ -1933,11 +1946,11 @@
                <td>Detect Thoughts
                </td>
                <td>
-                  You may sense intelligent creatures in a 20ft radius as spots of light when you close your eyes.
+                  You may sense intelligent creatures in a 15ft radius as spots of light when you close your eyes.
                   Creatures have to have an intelligence of at least 8 for you to be able to see them, and the more intelligent
                   the creature, the brighter the spots of light.
                </td>
-               <td>2 AP - 3 Uses
+               <td>1 Minute - 1 Use
                </td>
                <td>Psionic Level 3
                </td>
@@ -1969,7 +1982,7 @@
                   aware something tried to control their thoughts, but will not know the source unless you cast the 
                   ability right in front of them or they are very knowledgeable in psionic magic.
                </td>
-               <td>1 AP - 3 Uses
+               <td>1 AP - 1 Use
                </td>
                <td>Psionic Level 5
                </td>
@@ -1981,7 +1994,7 @@
                   You may become <a class="condition" data-tooltip-container>invisible</a> for 10 minutes. You can use this on a willing ally
                   within 25ft but the effect will only last 1 minute.
                </td>
-               <td>2 AP - 3 Uses
+               <td>2 AP - 1 Use
                </td>
                <td>Psionic Level 5
                </td>
@@ -1990,7 +2003,7 @@
                <td>Sleep
                </td>
                <td>
-                  You may send a target within 50ft to sleep until the start of your next turn. They receive the
+                  You may send a target within 50ft to sleep. They receive the
                   <a class="condition" data-tooltip-container>unconscious</a> condition, but if they receive any damage or negative status effect
                   they instantly wake up and are no longer <a class="condition" data-tooltip-container>unconscious</a>. This lasts for up to 8
                   hours (or however long the creature would normally sleep). A creature that
@@ -1999,7 +2012,7 @@
                   aware something tried to control their thoughts, but will not know the source unless you cast the 
                   ability right in front of them or they are very knowledgeable in psionic magic.
                </td>
-               <td>3 AP - 3 Uses
+               <td>3 AP - 1 Use
                </td>
                <td>Psionic Level 5
                </td>
@@ -2010,8 +2023,8 @@
                <td>
                   You may touch a creature to occupy it's head. You share its senses and can communicate with it via thoughts.
                   While this is happening are and are <a class="condition" data-tooltip-container>paralysed</a> and only slightly 
-                  aware of your surrondings.  You can influence this creature, giving it either adv (+) or dis (-) on each of its skill 
-                  checks.  You can end this at any time and it automatically ends if you take damage.
+                  aware of your surrondings. You can end this at any time and it automatically ends if you (not the creature) take
+                  damage.
 
                   2 WILL resist, and a further 1 WILL resist check every 5 minutes.  This can last up to 1 hour.
                </td>
@@ -2031,7 +2044,7 @@
                   aware something tried to control their thoughts, but will not know the source unless you cast the 
                   ability right in front of them or they are very knowledgeable in psionic magic.
                </td>
-               <td>3 AP - 3 Uses
+               <td>3 AP - 1 Use
                </td>
                <td>Psionic Level 7
                </td>
@@ -2097,7 +2110,7 @@
                </td>
                <td><strong>Desc</strong>
                </td>
-               <td><strong>Notes</strong>
+               <td><strong>Usage</strong>
                </td>
                <td><strong>Requirements</strong>
                </td>
@@ -2132,7 +2145,8 @@
                </td>
                <td>
                   You gain the ability to accelerate the growth of small plants, vines and vegetation in areas
-                  within 25ft. The longer you spend on the spell, the more significant the changes.
+                  within 10ft. The longer you spend on the spell, the more significant the changes.
+                  Causing a flower to go from seed to bloom takes approximately 10 minutes.
                </td>
                <td>No Use Limit
                </td>
@@ -2198,7 +2212,7 @@
                </td>
                <td><strong>Desc</strong>
                </td>
-               <td><strong>Notes</strong>
+               <td><strong>Usage</strong>
                </td>
                <td><strong>Requirements</strong>
                </td>
@@ -2210,6 +2224,7 @@
                   You may use INT instead of SPI for all Mortality abilities.
                </td>
                <td>
+                  Passive
                </td>
                <td>Mortality Level 1
                </td>
@@ -2242,10 +2257,10 @@
                <td>Detect Life
                </td>
                <td>
-                  You may sense living creatures in a 15ft radius as spots of soul energy when you close your eyes
+                  You may sense living creatures in a 10ft radius as spots of soul energy when you close your eyes
                   The larger the creature, the larger and brighter the the spots are.
                </td>
-               <td>2 AP - 3 Uses
+               <td>1 Minute - 1 Use
                </td>
                <td>Mortality Level 3
                </td>
@@ -2317,7 +2332,7 @@
                   3 AP spent. This ice will naturally melt after you no longer touch it based on the 
                   surrounding temperature.
                </td>
-               <td>3 AP - No Use Limit
+               <td>2 AP - No Use Limit
                </td>
                <td>Elemental Level 1
                </td>
@@ -2342,7 +2357,18 @@
                   You may summon localised weather, such as making it rain or sunny on command. The
                   weather reverts to normal after 10 minutes. This weather cannot be extreme or harmful.
                </td>
-               <td>3 AP - no use limit
+               <td>3 AP - 1 Use
+               </td>
+               <td>Elemental Level 3
+               </td>
+            </tr>
+            <tr>
+               <td>Unnatural Wind
+               </td>
+               <td>
+                  You may create a strong wind in any direction in an area within 25ft.  
+               </td>
+               <td>3 AP - 1 Use
                </td>
                <td>Elemental Level 3
                </td>
@@ -2377,7 +2403,7 @@
                   </td>
                   <td><strong>Desc</strong>
                   </td>
-                  <td><strong>Notes</strong>
+                  <td><strong>Usage</strong>
                   </td>
                   <td><strong>Requirements</strong>
                   </td>
@@ -2390,6 +2416,7 @@
                      or a crossbow.
                   </td>
                   <td>
+                     Passive
                   </td>
                   <td>Engineer Level 1
                   </td>
@@ -2426,6 +2453,20 @@
                   </td>
                </tr>
                <tr>
+                  <td>Windup Toy
+                  </td>
+                  <td>
+                     You may place a small wind up toy that runs forward up to 30ft, creating a simple
+                     noise of your choice.  
+
+                     If you recover your toy, you can reuse it without having to make another over a long rest.
+                  </td>
+                  <td>1 AP - 1 Use (Recoverable)
+                  </td>
+                  <td>Engineer Level 1
+                  </td>
+               </tr>
+               <tr>
                   <td>Mechanical Modification
                   </td>
                   <td>
@@ -2435,7 +2476,7 @@
                      This doesn't work on the engineer’s own constructs, as they are already
                      at the best of their ability.
                   </td>
-                  <td>3 AP - 3 Uses
+                  <td>1 Minute - 3 Uses
                   </td>
                   <td>Engineer Level 3
                   </td>

--- a/index.html
+++ b/index.html
@@ -1359,7 +1359,7 @@
                   any kind.
                </td>
                <td>
-                  Once per short rest.
+                  Once per Short Rest
                </td>
                <td>None
                </td>
@@ -1373,7 +1373,7 @@
                   short rest. You can also apply a disguise to another willing creature.
                </td>
                <td>
-                  30 minutes - No use limit.
+                  30 minutes - No Use Limit
                </td>
                <td>None
                </td>
@@ -1402,7 +1402,7 @@
                   checks to sneak or <a class="condition" data-tooltip-container>hide</a> that are affected by vision. This can be done during a short rest.
                </td>
                <td>
-                  30 minutes - no use limit.
+                  30 minutes - No Use Limit
                </td>
                <td>Master of Disguise or Global Level 5
                </td>
@@ -1452,7 +1452,7 @@
                <td>
                   You learn a how to play a new musical instrument (can be taken multiple times).
 
-                  This also gives you advantages on checks on similar instruments.
+                  This also gives you advantage (+) on checks on similar instruments.
                </td>
                <td>
                   Passive
@@ -1480,7 +1480,7 @@
                   instead of healing yourself for that amount.
                </td>
                <td>
-                  Once per short rest
+                  Once per Short Rest
                </td>
                <td>None
                </td>

--- a/index.html
+++ b/index.html
@@ -1753,7 +1753,7 @@
                <td>
                   You may create a spectral object within 5ft that occupies up to a 5*5*5ft cube. This object is solid and  
                   takes a form of your desire (e.g. chair, ramp, barricade). You may decide whether the object is moveable 
-                  or not: if moveable it will weigh around 1kg, ; if not moveable it will exist solidly floating in space and 
+                  or not: if moveable it will weigh around 1kg; if not moveable it will exist solidly floating in space and 
                   can support a weight of 200kg before breaking. It has an AC of 6 and Light HP.
                   
                   You can dismiss this at any time for 0AP, and it persists till the end of your next long rest.

--- a/index.html
+++ b/index.html
@@ -1447,6 +1447,20 @@
                </td>
             </tr>
             <tr>
+               <td>Muscian
+               </td>
+               <td>
+                  You learn a how to play a new musical instrument (can be taken multiple times).
+
+                  This also gives you advantages on checks on similar instruments.
+               </td>
+               <td>
+                  Passive
+               </td>
+               <td>None
+               </td>
+            </tr>
+            <tr>
                <td>Perceptive
                </td>
                <td>

--- a/index.html
+++ b/index.html
@@ -1345,28 +1345,6 @@
                </td>
             </tr>
             <tr>
-               <td>Purity of Body
-               </td>
-               <td>
-                  When you take a short rest you also regain 1 FORT and 1 REFL point.
-               </td>
-               <td>
-               </td>
-               <td>None
-               </td>
-            </tr>
-            <tr>
-               <td>Purity of Mind
-               </td>
-               <td>
-                  When you take a short rest you also regain 2 WILL points.
-               </td>
-               <td>
-               </td>
-               <td>None
-               </td>
-            </tr>
-            <tr>
                <td>Inspirational (Speaker, Entertainer, Cook)
                </td>
                <td>
@@ -1489,6 +1467,29 @@
                   3AP - 3 Uses
                </td>
                <td>Global Level 3 or Nature Level 1
+               </td>
+            </tr>
+            <tr>
+               <td>Purity of Body
+               </td>
+               <td>
+                  When you take a short rest you can regain 5 resistance points of your choice instead of healing.
+               </td>
+               <td>
+               </td>
+               <td>Global Level 3
+               </td>
+            </tr>
+            <tr>
+               <td>Purity of Mind
+               </td>
+               <td>
+                  You can spend 5 resistance points of your choice to gain another 3AP this turn.
+               </td>
+               <td>
+                  1 AP, 1 Use.
+               </td>
+               <td>Global Level 10
                </td>
             </tr>
             <tr>
@@ -1693,19 +1694,6 @@
                </td>
             </tr>
             <tr>
-               <td>Arcane Repair
-               </td>
-               <td>
-                  You may repair a damaged non magical object using magic. You can repair approximately 
-                  1 cubic foot of material per minute of using this ability, though this will be longer 
-                  if the item/material is more complex.
-               </td>
-               <td>3 AP - No Use Limit
-               </td>
-               <td>Arcane Level 1
-               </td>
-            </tr>
-            <tr>
                <td>Detect Magic
                </td>
                <td>
@@ -1727,6 +1715,21 @@
                   25ft. It has an AC of 14, Light HP, no resistance points, a STR value of 2 (-4 modifier), and a 
                   base movement speed of 5ft. You can make INT+DEX checks to perform more challenging dexterous 
                   actions with the hand using your own modifiers. The hand persists for 6 seconds before disappearing.
+               </td>
+               <td>1 AP - 3 Uses
+               </td>
+               <td>Arcane Level 3
+               </td>
+            </tr>
+            <tr>
+               <td>Spectral Object
+               </td>
+               <td>
+                  You may create a spectral object that occupies up to a 5*5*5ft cube.  This object is solid, 
+                  takes a form of your desire (e.g. chair, ramp, barricade), and can support a weight of up to 200kg
+                  without breaking.  It has an AC of 6 and Light HP.
+                  
+                  You can dismiss this at any time for 0AP, and it persists till the end of your next long rest.
                </td>
                <td>1 AP - 3 Uses
                </td>
@@ -2005,14 +2008,14 @@
                <td>Occupy
                </td>
                <td>
-                  You may touch a creature to occupy it's head. You see through it's eyes and can communicate with it via thoughts.
-                  While this is happening are and are <a class="condition" data-tooltip-container>immobilised</a> and only slightly 
+                  You may touch a creature to occupy it's head. You share its senses and can communicate with it via thoughts.
+                  While this is happening are and are <a class="condition" data-tooltip-container>paralysed</a> and only slightly 
                   aware of your surrondings.  You can influence this creature, giving it either adv (+) or dis (-) on each of its skill 
                   checks.  You can end this at any time and it automatically ends if you take damage.
 
-                  2 WILL resist, and a further 1 WILL resist check every 5 minutes.
+                  2 WILL resist, and a further 1 WILL resist check every 5 minutes.  This can last up to 1 hour.
                </td>
-               <td>3 AP - 3 Uses
+               <td>3 AP - 1 Use
                </td>
                <td>Psionic Level 7
                </td>
@@ -2043,7 +2046,7 @@
                   aware something tried to control their thoughts, but will not know the source unless you cast the 
                   ability right in front of them or they are very knowledgeable in psionic magic.
                </td>
-               <td>3 AP - 3 Uses
+               <td>3 AP - 1 Use
                </td>
                <td>Psionic Level 10
                </td>
@@ -2072,13 +2075,16 @@
                </td>
                <td>
                   You may touch a creature to walk through it's mind, glimpsing memories of its past. 
-                  You can direct what you see by asking to recall specific events.
-                  You and the creature are <a class="condition" data-tooltip-container>immobilised</a>
+                  You can direct what you see by asking to recall specific events.  These memories may
+                  be imperfect, hazy, or nonexistant.   
+                  You and the creature are <a class="condition" data-tooltip-container>paralysed</a>
+                  and <a class="condition" data-tooltip-container>blind</a>
                   for the duration of this trait.  You are free to end this at any time.
 
-                  2 WILL resist, and a further 1 WILL resist check every 6 seconds.
+                  2 WILL resist, and a further 1 WILL resist check every 6 seconds.  
+                  This can last up to 1 minute.  
                </td>
-               <td>3 AP - 3 Uses
+               <td>3 AP - 1 Use
                </td>
                <td>Psionic Level 10
                </td>
@@ -2342,34 +2348,19 @@
                </td>
             </tr>
             <tr>
-               <td>Elemental Aspect
-               </td>
-               <td>
-                  When you use non-magical weapons you can channel elemental energy, causing them to deal 
-                  either fire, frost, or lightning damage instead of physical.  You can only 
-                  select one type of damage when taking this trait.
-
-                  You can take this trait multiple times to unlock the other types of damage.
-               </td>
-               <td>
-               </td>
-               <td>Elemental Level 3
-               </td>
-            </tr>
-            <tr>
                <td>Elemental Weapons
                </td>
                <td>
-                  You can summon an weapon made out of elemental energy, causing them to deal 
-                  either fire, frost, or lightning damage instead of physical.  You can only 
-                  select one type of damage when taking this trait.  These are still wielded
-                  using the rules of their physical couterparts - e.g. STR is used for a heavy
-                  weapon.
+                  You may weild a weapon made out of the elements, either by summoning a new weapon
+                  or coating an existing weapon with the elemental of your choice for 1AP. This causes them to deal 
+                  either fire, frost, or lightning damage instead of the weapon's normal damage type.  
+                  You can only select one type of damage when taking this trait.  These are still wielded
+                  using the modifiers (STR or DEX) of their normal counterparts.  
 
                   You can take this trait multiple times to unlock the other types of damage.
 
-                  You can dismiss this at any time, and the weapon disappears when you let go of it, 
-                  rest, or are <a class="condition" data-tooltip-container>silenced</a> or
+                  You can dismiss this at any time, and the element disappears when you let go of it, 
+                  rest, are <a class="condition" data-tooltip-container>silenced</a> or
                   <a class="condition" data-tooltip-container>unconscious</a>.
                </td>
                <td>
@@ -2421,11 +2412,13 @@
                   </td>
                   <td>
                      You may place a tripwire across 15ft.  When these are crossed by a creature, 
-                     you are aware they've been set off and the size of the creature which triggered them.
+                     you are aware they've been set off and the size of the creature which triggered them
+                     or they create a loud noise, your choice.
                      This wakes you up if during a long rest, and they persist until you deconstruct them,
                      they are triggered, or till the end of a long rest.
 
-                     These can be bypassed by a creature which is intelligent and perceptive enough.
+                     These can be spotted by a creature who's Passive Perception passes your INT value,
+                     and disarmed by a creature with an INT+DEX check with a DC of your INT value.
                   </td>
                   <td>1 AP - 3 Uses
                   </td>


### PR DESCRIPTION
Some more traits and a few of level changes.  I fully expect you to fiddle with wording.

Some thoughts in this PR.  I wanted to make a couple of interesting traits for Psionic that could really enhance role playing scenarios.   Added a couple of Elemental traits that are mostly flavour, but opens the possibility for a couple of things.

Some thoughts which aren't covered in this PR.
- I think traits should be something which isn't just generally good, Purity of Body/Mind creep into this a bit much for me.
- Still not super onboard with the climbing/swimming traits, maybe it's fine but feels pretty close to just skills
- It's incredibly slow to get traits at high level, if you want to get all the lvl 10 psionics you'll have to be lvl 16 - is this an issue?
- I kinda see why DnD has spell limits.  Feels a bit weird to be able to burn your "truth tell" 3 times to grind them down without really repercussions, but restricting to less than 3 uses might suck in the odd time you want to cast it legitimately.
- Not against just removing Arcane repair.  Arcane is kinda like meta-magic, bit weird that it can affect physical delicately as it's the only instance of it.  Who says we need magical repair anyway?  Happy to go against the perceived wisdom on this, they can go engineer/do skill checks if they feel a big need for it.