### PR TITLE
One attribute per roll overhaul

### DIFF
--- a/public/class_abilities.yaml
+++ b/public/class_abilities.yaml
@@ -516,7 +516,7 @@ classes:
         name: Elemental Balance
         apCost: "-"
         flavourText: You have mastered the balance of mind and spirit.
-        description: You may use either INT or SPI as your modifiers for any elemental abilities. In this table these attributes will be referred to as MOD and Modifiers (modifiers of your choice). E.g. Medium+MOD+MOD attack power = Medium+INT+INT or Medium+SPI+SPI attack power.
+        description: "You may use either INT or SPI as your attribute for any elemental abilities. In this table these attributes will be referred to as ATR (attribute of your choice). E.g. Medium+ATR attack power -> Medium+INT or Medium+SPI attack power."
         range: "-"
         target: Self
         type: Passive
@@ -525,7 +525,7 @@ classes:
         name: Elemental Blast
         apCost: 2
         flavourText: Conjure a burst of elemental power.
-        description: Make a melee MOD attack against a creature with Medium+MOD+MOD (fire, frost, lightning, or physical) attack power, or a ranged attack against a creature within 50ft with Light+MOD+MOD (fire, frost, lightning, or physical) attack power. At level 5 in Elemental, the ranged attack increases from Light attack power to Medium.
+        description: Make a melee MOD attack against a creature with Medium+ATR (fire, frost, lightning, or physical) attack power, or a ranged attack against a creature within 50ft with Light+ATR (fire, frost, lightning, or physical) attack power. At level 5 in Elemental, the ranged attack increases from Light attack power to Medium.
         range: 50ft
         target: A+E, Single target
         type: Active
@@ -546,7 +546,7 @@ classes:
         flavourText: Summon shards of ice that orbit around you.
         description: Create 3 ice daggers that persist with you until the end of your next turn. You cannot have more than 3 ice daggers at any one time.
         extraEffectCost: 1 AP + 1 Ice Dagger
-        extraEffectDescription: Make a ranged MOD attack against a creature within 50ft with Light+MOD+MOD frost attack power targeting FORT or REFL.
+        extraEffectDescription: Make a ranged MOD attack against a creature within 50ft with Light+ATR frost attack power targeting FORT or REFL.
         range: 50ft
         target: A+E, Single target
         type: Active
@@ -556,7 +556,7 @@ classes:
         apCost: 2
         otherCost: 1 REFL or WILL
         flavourText: Push your foes with a forceful gust.
-        description: Make a versatile MOD attack against a creature within 50ft with Medium+MOD+MOD attack power targeting FORT or REFL. The creature is pushed 15ft in a straight line in a direction of your choice. Target may resist the push with FORT or REFL.
+        description: Make a versatile MOD attack against a creature within 50ft with Medium+ATR attack power targeting FORT or REFL. The creature is pushed 15ft in a straight line in a direction of your choice. Target may resist the push with FORT or REFL.
         range: 50ft
         target: A+E, Single target
         type: Active
@@ -566,7 +566,7 @@ classes:
         apCost: 2
         otherCost: 1 FORT or WILL
         flavourText: Unleash a ray as powerful as the sun.
-        description: Make a versatile MOD attack against all creatures in up to a 20ft line originating from you with Medium+MOD+MOD fire attack power targeting REFL.
+        description: Make a versatile MOD attack against all creatures in up to a 20ft line originating from you with Medium+ATR fire attack power targeting REFL.
         range: 20ft
         target: A+E, All within straight line from self (AoE)
         type: Active
@@ -606,7 +606,7 @@ classes:
         apCost: 2
         otherCost: 2 WILL
         flavourText: Throw an explosive ball of flame.
-        description: Select a tile within 50ft. All creatures within 5ft are attacked with Heavy+MOD+MOD fire attack power targeting REFL.
+        description: Select a tile within 50ft. All creatures within 5ft are attacked with Heavy+ATR fire attack power targeting REFL.
         extraEffectCost: 2 WILL
         extraEffectDescription: Double the attack power of the attack against all creatures.
         range: 50ft
@@ -618,7 +618,7 @@ classes:
         apCost: 2
         otherCost: 2 REFL or WILL
         flavourText: Invoke a shocking bolt of lightning.
-        description: Make a versatile MOD attack against a creature within 50ft with Medium+MOD+MOD lightning attack power targeting REFL or WILL. The creature is also dazed, and you may then select another creature within 5ft of the original target which also becomes dazed. Target may resist the daze with REFL or WILL.
+        description: Make a versatile MOD attack against a creature within 50ft with Medium+ATR lightning attack power targeting REFL or WILL. The creature is also dazed, and you may then select another creature within 5ft of the original target which also becomes dazed. Target may resist the daze with REFL or WILL.
         range: 50ft
         target: A+E, Single target
         type: Active
@@ -638,7 +638,7 @@ classes:
         apCost: "-"
         otherCost: 1 REFL or WILL and your reaction
         flavourText: Engulf yourself in flames to fight back.
-        description: When you are hit by a melee attack, you may make a melee MOD attack against the attacking creature with Light+MOD+MOD fire attack power targeting REFL or WILL.
+        description: When you are hit by a melee attack, you may make a melee MOD attack against the attacking creature with Light+ATR fire attack power targeting REFL or WILL.
         range: Melee
         target: A+E, Single target
         type: Active
@@ -658,7 +658,7 @@ classes:
         apCost: 2
         otherCost: 1 FORT or WILL
         flavourText: Drop a large spiked rock on your foe.
-        description: Make a versatile MOD attack against a creature within 50ft with Medium+MOD+MOD attack power targeting FORT or REFL. If the creature is prone or immobilised, gain additional Medium attack power.
+        description: Make a versatile MOD attack against a creature within 50ft with Medium+ATR attack power targeting FORT or REFL. If the creature is prone or immobilised, gain additional Medium attack power.
         range: 50ft
         target: A+E, Single target
         type: Active
@@ -693,7 +693,7 @@ classes:
         name: Soul Strike
         apCost: 2
         flavourText: Lash out at another's soul.
-        description: Make a ranged SPI attack against a creature within 100ft with Medium+MOD+MOD soul attack power.
+        description: Make a ranged SPI attack against a creature within 100ft with Medium+ATR soul attack power.
         range: 100ft
         target: A+E, Single target
         type: Active
@@ -712,7 +712,7 @@ classes:
         apCost: 1
         otherCost: 1 FORT or WILL - Deadly Escalation
         flavourText: Restore part of a being's soul.
-        description: Select a creature within 100ft and heal them for 3+SPI HP.
+        description: Select a creature within 100ft and heal them for 1+SPI HP.
         range: 100ft
         target: All, Single target
         type: Active
@@ -722,7 +722,7 @@ classes:
         apCost: 1
         otherCost: 2 FORT or WILL - Deadly Escalation
         flavourText: Create a burst of healing energy that restores all in proximity.
-        description: Select a tile within 100ft, heal all creatures within 5ft for 1+SPI HP.
+        description: Select a tile within 100ft, heal all creatures within 5ft for SPI-1 HP (minimum 1).
         range: 100ft
         target: All, All within 5ft (AoE)
         type: Active
@@ -742,7 +742,7 @@ classes:
         apCost: "-"
         otherCost: 1 WILL and your reaction
         flavourText: Exploit the last of a creature's essence to maim your foe.
-        description: When you reduce a creature within 100ft to 0 HP, you may spend 1 WILL and your reaction to make a versatile SPI attack against another creature within 15ft of the initial target with Medium+MOD+MOD soul attack power. It must specifically be you and your damage that reduces the creature to 0 HP.
+        description: When you reduce a creature within 100ft to 0 HP, you may spend 1 WILL and your reaction to make a versatile SPI attack against another creature within 15ft of the initial target with Medium+ATR soul attack power. It must specifically be you and your damage that reduces the creature to 0 HP.
         range: 100ft
         target: A+E, Single target within 15ft
         type: Active
@@ -762,7 +762,7 @@ classes:
         apCost: 2
         otherCost: 3 FORT or WILL
         flavourText: Drain life and grant it to another.
-        description: Make a versatile SPI attack against a creature within 100ft with Medium+MOD+MOD soul attack power targeting FORT or WILL. Then heal a creature (excluding self) for HP equal to the damage you dealt with this ability.
+        description: Make a versatile SPI attack against a creature within 100ft with Medium+ATR soul attack power targeting FORT or WILL. Then heal a creature (excluding self) for HP equal to the damage you dealt with this ability.
         range: 100ft
         target: All, Single target
         type: Active
@@ -772,7 +772,7 @@ classes:
         apCost: 2
         otherCost: 2 FORT or WILL - Deadly Escalation
         flavourText: Explode with restorative or destructive energy.
-        description: "Select any number of creatures within 10ft and then either: heal each creature for 2+SPI HP (includes self); or remove the Deadly Escalation cost and make a versatile SPI attack against each creature with Light+MOD+MOD soul attack power targeting FORT or WILL (excludes self). You cannot both heal and deal damage with one use of this ability."
+        description: "Select any number of creatures within 10ft and then either: heal each creature for SPI HP (includes self); or remove the Deadly Escalation cost and make a versatile SPI attack against each creature with Light+ATR soul attack power targeting FORT or WILL (excludes self). You cannot both heal and deal damage with one use of this ability."
         range: 10ft
         target: A+Self or E, All within range (AoE)
         type: Active
@@ -812,7 +812,7 @@ classes:
         apCost: 1
         otherCost: 2 FORT or WILL - Deadly Escalation
         flavourText: Positive energy emanates from you, healing yourself and those who get close.
-        description: Mark yourself, and when a creature moves within 5ft of you, you may heal both yourself and the creature for 2+SPI HP. This can only happen 3 times per ability use, and only once per creature.
+        description: Mark yourself, and when a creature moves within 5ft of you, you may heal both yourself and the creature for SPI HP. This can only happen 3 times per ability use, and only once per creature.
         range: 5ft
         target: A+Self, 3 within range (AoE)
         type: Active
@@ -832,7 +832,7 @@ classes:
         apCost: 2
         otherCost: 2 FORT or WILL
         flavourText: Detach a soul from a creature and shift it with lethal force.
-        description: Select a creature within 100ft and draw a 20ft line in a direction of your choice. Make a versatile SPI attack against all creatures in the line with Medium+SPI soul attack power.
+        description: Select a creature within 100ft and draw a 20ft line in a direction of your choice. Make a versatile SPI attack against all creatures in the line with Light+SPI soul attack power.
         range: 100ft
         target: A+E, All within 20ft straight line from target (AoE)
         type: Active
@@ -857,7 +857,7 @@ classes:
         name: Arcane Bolt
         apCost: 2
         flavourText: Launch a beam of pure force at your foe.
-        description: Make a ranged INT attack against a creature within 100ft with Medium+MOD+MOD force damage.
+        description: Make a ranged INT attack against a creature within 100ft with Medium+ATR force damage.
         range: 100ft
         target: A+E, Single target
         type: Active
@@ -896,7 +896,7 @@ classes:
         apCost: 2
         otherCost: 1 REFL or WILL
         flavourText: Emit a powerful short range blast to escape your enemies.
-        description: Make a melee INT attack against a creature with Heavy+MOD+MOD force damage targeting REFL or WILL. You are then pushed up to 20ft directly away from the target.
+        description: Make a melee INT attack against a creature with Heavy+ATR force damage targeting REFL or WILL. You are then pushed up to 20ft directly away from the target.
         range: Melee
         target: A+E, Single target
         type: Active
@@ -956,7 +956,7 @@ classes:
         apCost: 2
         otherCost: 2 FORT or WILL
         flavourText: Aggressively teleport towards a foe, forcing them out of your way.
-        description: Select a creature within 25ft, teleport to them and briefly occupy the same space as them. Make a melee INT attack against the initial target with Heavy+MOD+MOD force damage targeting FORT or WILL and is pushed to a tile of your choice within 5ft of you. Target may resist the push with FORT or WILL. If the creature resists the push it does not move, and you are pushed to a tile within 5ft of the creature instead.
+        description: Select a creature within 25ft, teleport to them and briefly occupy the same space as them. Make a melee INT attack against the initial target with Heavy+ATR force damage targeting FORT or WILL and is pushed to a tile of your choice within 5ft of you. Target may resist the push with FORT or WILL. If the creature resists the push it does not move, and you are pushed to a tile within 5ft of the creature instead.
         range: 25ft
         target: A+E, Single target
         type: Active
@@ -986,7 +986,7 @@ classes:
         apCost: 2
         otherCost: 2 FORT or WILL
         flavourText: Summon an invincible creature of pure energy that stands vigilant.
-        description: Select a tile within 100ft and summon an astral guardian creature. This creature is Large and takes up 3 tiles on a hex grid, and 4 on a square grid. Other creatures can move through this creature as if it were difficult terrain. This creature is invincible, has no stats, and cannot be moved. This creature cannot taunt other creatures. When a creature moves into a tile within 5ft of the astral guardian from outside this range, you may make an melee INT attack with Medium+MOD+MOD force attack power targeting WILL. In addition to this, the astral guardian may make attacks of opportunity with no limit. Each creature may only be damaged by the astral guardian once per round.
+        description: Select a tile within 100ft and summon an astral guardian creature. This creature is Large and takes up 3 tiles on a hex grid, and 4 on a square grid. Other creatures can move through this creature as if it were difficult terrain. This creature is invincible, has no stats, and cannot be moved. This creature cannot taunt other creatures. When a creature moves into a tile within 5ft of the astral guardian from outside this range, you may make an melee INT attack with Medium+ATR force attack power targeting WILL. In addition to this, the astral guardian may make attacks of opportunity with no limit. Each creature may only be damaged by the astral guardian once per round.
         range: 100ft
         target: A+E, All within 5ft (AoE)
         type: Active
@@ -1012,7 +1012,7 @@ classes:
         name: Psychic Pierce
         apCost: 2
         flavourText: Puncture a creatures mind as if taking a blade to their synapses.
-        description: Make a ranged INT attack against a creature within 100ft with Medium+MOD+MOD psychic attack power. If the target currently has 3 or more distinct negative conditions, the attack gains additional Light attack power.
+        description: Make a ranged INT attack against a creature within 100ft with Medium+ATR psychic attack power. If the target currently has 3 or more distinct negative conditions, the attack gains additional Light attack power.
         range: 100ft
         target: A+E, Single target
         type: Active
@@ -1071,7 +1071,7 @@ classes:
         apCost: 2
         otherCost: 2 WILL
         flavourText: Slowly emit a sense of pain and suffering.
-        description: "Select a creature within 100ft, make note of their current position, and hobble them. At the start of your next turn: If the selected creature is within 5ft of the noted position it suffers 5+INT WILL psychic damage. Or if it is within 20ft of the noted position it suffers 1+INT WILL psychic damage. Otherwise it suffers 2 WILL psychic damage. Target may resist the hobble with FORT or WILL."
+        description: "Select a creature within 100ft, make note of their current position, and hobble them. At the start of your next turn: If the selected creature is within 5ft of the noted position it suffers 3+INT WILL psychic damage. Or if it is within 20ft of the noted position it suffers INT-1 WILL psychic damage (minimum 1). Otherwise it suffers 2 WILL psychic damage. Target may resist the hobble with FORT or WILL."
         range: 100ft
         target: A+E, Single target
         type: Active
@@ -1081,7 +1081,7 @@ classes:
         apCost: 2
         otherCost: 3 WILL
         flavourText: Make a joke that cuts so deep it hurts.
-        description: "Make a versatile INT attack against a creature within 100ft, with Heavy+MOD+MOD psychic attack power targeting WILL. Double the attack power of this attack if the creature has any of the following conditions: charmed, dominated, taunted, frightened, feeble or silenced. The creature is then also taunted by you. Target may resist the taunt with WILL."
+        description: "Make a versatile INT attack against a creature within 100ft, with Heavy+ATR psychic attack power targeting WILL. Double the attack power of this attack if the creature has any of the following conditions: charmed, dominated, taunted, frightened, feeble or silenced. The creature is then also taunted by you. Target may resist the taunt with WILL."
         range: 100ft
         target: A+E, Single target
         type: Active

--- a/public/class_abilities.yaml
+++ b/public/class_abilities.yaml
@@ -40,7 +40,7 @@ classes:
       - level: 1
         name: Charge
         apCost: 2
-        otherCost: 1 FORT
+        otherCost: 2 FORT
         flavourText: Rush forward smashing all enemies in your path.
         description: Move up to 40ft in a straight line, moving through other creatures. Make a melee weapon attack against all creatures moved through targeting FORT.
         extraEffectCost: 1 FORT
@@ -52,7 +52,7 @@ classes:
       - level: 1
         name: Sweeping Strike
         apCost: 2
-        otherCost: 1 FORT or REFL
+        otherCost: 2 FORT or REFL
         flavourText: "-"
         description: Select 3 connected tiles all within 5ft. Make a melee weapon attack against all creatures on these tiles targeting FORT or REFL. All creatures attacked are knocked prone. Target may resist the prone with FORT or REFL.
         range: Melee
@@ -64,7 +64,9 @@ classes:
         apCost: 1
         otherCost: 1 FORT or REFL
         flavourText: "-"
-        description: Move up to 15ft and make a melee attack with Light attack power targeting FORT or REFL and push them to another tile within 15ft of you. Target may resist the push with FORT or REFL. The creature is then also knocked prone. Target may resist the prone with FORT or REFL.
+        description: Move up to 15ft and make a melee attack with Light attack power targeting FORT or REFL and push them to another tile within 15ft of you. Target may resist the push with FORT or REFL.
+        extraEffectCost: 1 FORT or REFL
+        extraEffectDescription: The creature is then also knocked prone. Target may resist the prone with FORT or REFL.
         range: Melee
         target: A+E, Single target
         type: Active
@@ -74,7 +76,9 @@ classes:
         apCost: 1
         otherCost: 1 FORT or WILL
         flavourText: "-"
-        description: Taunt all enemies within 30ft of you. Target may resist the taunt with FORT or WILL. You also gain Physical Resistance 1 and Resistance 1 for one other damage type of your choice.
+        description: Taunt all enemies within 30ft of you. Target may resist the taunt with FORT or WILL. You also gain Physical Resistance 1.
+        extraEffectCost: 1 FORT or WILL
+        extraEffectDescription: Gain Resistance 1 for one additional damage type of your choice.
         range: 30ft
         target: E, All within range (AoE)
         type: Active
@@ -82,9 +86,9 @@ classes:
       - level: 1
         name: Danger Close
         apCost: "-"
-        otherCost: 1 FORT or REFL in addition to your reaction
+        otherCost: 1 FORT or REFL + Reaction
         flavourText: Strike at those who dare approach you.
-        description: Then, when a creature moves into a tile within 5ft of you (voluntarily or involuntarily), you may make a melee attack that creature with Light attack power. Each creature can only be damaged by this ability once per cast. This ability has no effect when you are the one moving.
+        description: When a creature moves into a tile within 5ft of you (voluntarily or involuntarily), you may make a melee attack that creature with Light attack power. Each creature can only be damaged by this ability once per cast. This ability has no effect when you are the one moving.
         extraEffectCost: 2 FORT or REFL
         extraEffectDescription: Increase the attack power to that of your melee weapon.
         range: 5ft
@@ -94,7 +98,7 @@ classes:
       - level: 2
         name: Whirlwind
         apCost: 2
-        otherCost: 1 FORT or REFL
+        otherCost: 2 FORT or REFL
         flavourText: Ferociously swing your weapon around you, striking all nearby creatures.
         description: Make a melee weapon attack against all creatures within weapon range, targeting FORT or REFL.
         range: Melee
@@ -133,9 +137,9 @@ classes:
         tags: [attack, debuff]
       - level: 3
         name: Savage Leap
-        apCost: 3
-        otherCost: 3 FORT
-        flavourText: Leap forward and use your momentum to strike harder.
+        apCost: 2
+        otherCost: 4 FORT
+        flavourText: Leap forward and put all of your momentum into your strike.
         description: Select a tile you can see within 20ft and jump to that tile. You may then immediately make a melee attack against a creature targeting FORT. This attack gains additional Medium attack power for each tile you moved (distance in ft divided by 5).
         range: 20ft/Melee
         target: A+E, Single target
@@ -165,7 +169,7 @@ classes:
         name: Pin and Crush
         apCost: 1
         flavourText: Pin a foe and ready your weapon for a massive attack.
-        description: Select a creature within 5ft and immobilise it. Target may resist the immobilise with FORT or REFL. At the start of your next turn, before performing any other actions, you may immediately spend 1 FORT or REFL and 1 additional AP to make a melee weapon attack against the same creature targeting FORT or REFL. This attack gains additional Medium attack power.
+        description: Select a creature within 5ft and immobilise it. Target may resist the immobilise with FORT or REFL. At the start of your next turn, before performing any other actions, you may immediately spend 1 FORT or REFL and 1 AP to make a melee weapon attack against the same creature targeting FORT or REFL. This attack gains additional Medium attack power.
         range: Melee
         target: A+E, Single target
         type: Active
@@ -190,7 +194,7 @@ classes:
         name: Swift Striker
         apCost: "-"
         flavourText: Move fast and strike faster.
-        description: At any time on your turn, if you have moved to a position that is 30ft or further away from where you started your turn, your next attack against a single target has Adv (++).
+        description: During your turn, if you have moved to a position that is at least 30ft from where you started your turn, your next attack against a single target has Adv (++).
         range: "-"
         target: Self
         type: Passive
@@ -222,7 +226,7 @@ classes:
       - level: 1
         name: Flashbang
         apCost: 1
-        otherCost: 1 REFL or WILL
+        otherCost: 2 REFL or WILL
         flavourText: Dazzle your foes with a small explosive.
         description: Select a tile within 50ft and blind all creatures within a 10ft. Target may resist the blind with REFL or WILL.
         range: 50ft
@@ -232,9 +236,9 @@ classes:
       - level: 1
         name: Expose Weakness
         apCost: 2
-        otherCost: 1 REFL or WILL
+        otherCost: 2 REFL or WILL
         flavourText: Reveal your foe's greatest strengths and weaknesses.
-        description: Make a weapon attack against a creature targeting REFL or WILL. The creature becomes marked. Then choose any energy type, the creature rolls 3 fewer d6 when attempting to resist incoming conditions for that energy type. You also learn all of the creature's vulnerabilities, resistances, and immunities.
+        description: Make a weapon attack against a creature targeting REFL or WILL. The creature becomes marked. Then choose any energy type, the creature rolls half the number of d6 (rounded down) when attempting to resist incoming conditions for that energy type. You also learn all of the creature's vulnerabilities, resistances, and immunities.
         range: Weapon
         target: A+E, Single target
         type: Active
@@ -251,7 +255,7 @@ classes:
       - level: 2
         name: Poisoned Strike
         apCost: 2
-        otherCost: 2 FORT or REFL
+        otherCost: 3 FORT or REFL
         flavourText: Coat your weapon in a sickening poison.
         description: Make a weapon attack against a creature targeting FORT or REFL. Then for each energy type that the creature has no remaining energy, it suffers additional 2 direct poison damage. The creature also becomes poisoned. Target may resist the poison with FORT or WILL.
         range: Weapon
@@ -273,9 +277,9 @@ classes:
         apCost: 3
         otherCost: 1 FORT or REFL
         flavourText: Rapidly reposition and attack.
-        description: Move up to 150ft and make a melee or ranged weapon attack against a creature targeting FORT or REFL. This movement may be broken up by the attack. The creature is also hobbled. Target may resist the hobble with FORT or REFL.
-        extraEffectCost: 1 FORT or REFL
-        extraEffectDescription: The creature additionally gains bleeding. Target may resist the bleed with FORT or REFL.
+        description: Move up to 150ft and make a melee or ranged weapon attack against a creature targeting FORT or REFL. This movement may be broken up by the attack.
+        extraEffectCost: 2 FORT or REFL
+        extraEffectDescription: The creature additionally gains the hobbled and bleeding conditions. Target may resist the both conditions simultaneously with FORT or REFL.
         range: Weapon
         target: A+E, Single target
         type: Active
@@ -324,7 +328,7 @@ classes:
         name: Headshot
         apCost: 2
         otherCost: 2 REFL or WILL
-        flavourText: Daze your target with a well timed blow to the head.
+        flavourText: Rock your target with a well timed blow to the head.
         description: Make a weapon attack against a creature. On a hit the creature is stunned. Target may resist the stun with FORT or WILL.
         range: Weapon
         target: A+E, Single target
@@ -356,7 +360,7 @@ classes:
         type: Passive
         tags: [attack]
       - level: Core
-        name: Commanding Movement
+        name: Move With Me!
         apCost: "-"
         flavourText: Order others to reposition with the flow of battle.
         description: Whenever you use the core movement ability, you may spend either 10ft or 20ft of that movement speed to grant an ally within 50ft either 5ft or 10ft of movement respectively to be spent immediately.
@@ -377,10 +381,9 @@ classes:
       - level: 1
         name: Forceful Shot
         apCost: 2
+        otherCost: 1 FORT or REFL
         flavourText: Push back your enemies with a projectile of great force.
-        description: Make a ranged weapon attack against a creature targeting FORT or REFL. The creature is pushed 5ft directly away from you. Target may resist the push with FORT or REFL. This attack ignores any disadvantage due to being within 5ft.
-        extraEffectCost: 1 FORT or REFL
-        extraEffectDescription: Increase the push distance to 20ft.
+        description: Make a ranged weapon attack against a creature targeting FORT or REFL. The creature is pushed 20ft directly away from you. Target may resist the push with FORT or REFL. This attack ignores any disadvantage due to being within 5ft.
         range: Weapon
         target: A+E (Ranged weapon required), Single target
         type: Active
@@ -427,7 +430,7 @@ classes:
       - level: 2
         name: Piercing Shot
         apCost: 2
-        otherCost: 1 FORT or REFL
+        otherCost: 2 FORT or REFL
         flavourText: Strike through foes with a piercing projectile.
         description: Make a ranged weapon attack against all creatures in a 30ft line originating from you targeting FORT or REFL. This attack ignores any disadvantage due to being within 5ft.
         range: 30ft
@@ -479,7 +482,7 @@ classes:
       - level: 3
         name: Opportunist
         apCost: "-"
-        otherCost: 1 REFL and your reaction
+        otherCost: 2 REFL and your reaction
         flavourText: Seize every opportunity to strike.
         description: When an ally within weapon range makes an attack of opportunity against a creature, you may spend 1 REFL and your reaction to make a ranged weapon attack against the same creature.
         range: Weapon
@@ -498,9 +501,9 @@ classes:
       - level: 3
         name: Bring It Down!
         apCost: 1
-        otherCost: 1 FORT or REFL
+        otherCost: 2 FORT or REFL
         flavourText: Command your allies to bring a foe to its knees.
-        description: Select a creature within 100ft and mark it. Also select one energy type for which it has 1 or more points remaining. At the start of your next turn if the creature has 0 points remaining in the chosen type you may force the creature to lose resistance points equal to half the number of points it lost in the chosen type (rounded up).
+        description: Select a creature within 100ft and mark it. Also select one energy type for which it has 5 or more points remaining. At the start of your next turn if the creature has 0 points remaining in the chosen type you may force the creature to lose 5 energy in different type.
         range: 100ft
         target: A+E, Single target
         type: Active

--- a/public/class_abilities.yaml
+++ b/public/class_abilities.yaml
@@ -484,7 +484,7 @@ classes:
         apCost: "-"
         otherCost: 2 REFL and your reaction
         flavourText: Seize every opportunity to strike.
-        description: When an ally within weapon range makes an attack of opportunity against a creature, you may spend 1 REFL and your reaction to make a ranged weapon attack against the same creature.
+        description: When an ally within weapon range makes an attack of opportunity against a creature, you may make a ranged weapon attack against the same creature.
         range: Weapon
         target: A+E (Ranged weapon required), Single target
         type: Active
@@ -528,7 +528,7 @@ classes:
         name: Elemental Blast
         apCost: 2
         flavourText: Conjure a burst of elemental power.
-        description: Make a melee MOD attack against a creature with Medium+ATR (fire, frost, lightning, or physical) attack power, or a ranged attack against a creature within 50ft with Light+ATR (fire, frost, lightning, or physical) attack power. At level 5 in Elemental, the ranged attack increases from Light attack power to Medium.
+        description: Make a melee ATR attack against a creature with Medium+ATR (fire, frost, lightning, or physical) attack power, or a ranged attack against a creature within 50ft with Light+ATR (fire, frost, lightning, or physical) attack power. At level 5 in Elemental, the ranged attack increases from Light attack power to Medium.
         range: 50ft
         target: A+E, Single target
         type: Active
@@ -545,11 +545,11 @@ classes:
       - level: 1
         name: Ice Spikes
         apCost: 0
-        otherCost: 1 FORT or WILL
+        otherCost: 2 FORT or WILL
         flavourText: Summon shards of ice that orbit around you.
         description: Create 3 ice daggers that persist with you until the end of your next turn. You cannot have more than 3 ice daggers at any one time.
         extraEffectCost: 1 AP + 1 Ice Dagger
-        extraEffectDescription: Make a ranged MOD attack against a creature within 50ft with Light+ATR frost attack power targeting FORT or REFL.
+        extraEffectDescription: Make a ranged ATR attack against a creature within 50ft with Medium frost attack power targeting FORT or REFL.
         range: 50ft
         target: A+E, Single target
         type: Active
@@ -559,7 +559,7 @@ classes:
         apCost: 2
         otherCost: 1 REFL or WILL
         flavourText: Push your foes with a forceful gust.
-        description: Make a versatile MOD attack against a creature within 50ft with Medium+ATR attack power targeting FORT or REFL. The creature is pushed 15ft in a straight line in a direction of your choice. Target may resist the push with FORT or REFL.
+        description: Make a versatile ATR attack against a creature within 50ft with Medium+ATR attack power targeting FORT or REFL. The creature is pushed 15ft in a straight line in a direction of your choice. Target may resist the push with FORT or REFL.
         range: 50ft
         target: A+E, Single target
         type: Active
@@ -567,9 +567,9 @@ classes:
       - level: 1
         name: Sun Beam
         apCost: 2
-        otherCost: 1 FORT or WILL
+        otherCost: 2 FORT or WILL
         flavourText: Unleash a ray as powerful as the sun.
-        description: Make a versatile MOD attack against all creatures in up to a 20ft line originating from you with Medium+ATR fire attack power targeting REFL.
+        description: Make a versatile ATR attack against all creatures in up to a 20ft line originating from you with Medium+ATR fire attack power targeting REFL.
         range: 20ft
         target: A+E, All within straight line from self (AoE)
         type: Active
@@ -577,7 +577,7 @@ classes:
       - level: 1
         name: Elemental Grapple
         apCost: 2
-        otherCost: 1 FORT or WILL
+        otherCost: 2 FORT or WILL
         flavourText: Launch an elemental grapple that pulls a foe to you.
         description: Select a creature within 40ft and pull it to an unoccupied space within 5ft of you. The target suffers 1 (fire, frost, lightning, or physical) damage for every 10ft the creature is moved. For example, a distance of 25ft would result in 2 damage. Target may resist the pull with FORT or REFL.
         range: 40ft
@@ -599,7 +599,7 @@ classes:
         apCost: 1
         otherCost: 1 FORT or WILL
         flavourText: A large rock erupts from the ground and then explodes.
-        description: Select a tile on the ground within 50ft, any creature stood on this tile is knocked prone. Then all prone creatures within 5ft of this tile, including the initial target, suffer 2 damage. Target may resist the prone with REFL or FORT.
+        description: Select a tile on the ground within 50ft, the creature on this tile is knocked prone. Then all prone creatures within 5ft of this tile, including the initial target, suffer 2 FORT damage. Target may resist the prone with REFL or FORT.
         range: 50ft
         target: A+E, Single target
         type: Active
@@ -607,10 +607,10 @@ classes:
       - level: 2
         name: Fireball
         apCost: 2
-        otherCost: 2 WILL
+        otherCost: 4 WILL
         flavourText: Throw an explosive ball of flame.
         description: Select a tile within 50ft. All creatures within 5ft are attacked with Heavy+ATR fire attack power targeting REFL.
-        extraEffectCost: 2 WILL
+        extraEffectCost: 3 WILL
         extraEffectDescription: Double the attack power of the attack against all creatures.
         range: 50ft
         target: All, All within 5ft (AoE)
@@ -619,9 +619,11 @@ classes:
       - level: 2
         name: Lightning Strike
         apCost: 2
-        otherCost: 2 REFL or WILL
+        otherCost: 3 REFL or WILL
         flavourText: Invoke a shocking bolt of lightning.
-        description: Make a versatile MOD attack against a creature within 50ft with Medium+ATR lightning attack power targeting REFL or WILL. The creature is also dazed, and you may then select another creature within 5ft of the original target which also becomes dazed. Target may resist the daze with REFL or WILL.
+        description: Make a versatile ATR attack against a creature within 50ft with Medium+ATR lightning attack power targeting REFL or WILL. The creature is also stunned. Target may resist the stun with REFL or WILL.
+        extraEffectCost: 1 REFL or WILL
+        extraEffectDescription: Also daze all creatures within 5ft of the initial target. REFL or WILL to resist the daze.
         range: 50ft
         target: A+E, Single target
         type: Active
@@ -641,7 +643,7 @@ classes:
         apCost: "-"
         otherCost: 1 REFL or WILL and your reaction
         flavourText: Engulf yourself in flames to fight back.
-        description: When you are hit by a melee attack, you may make a melee MOD attack against the attacking creature with Light+ATR fire attack power targeting REFL or WILL.
+        description: When you are damaged by a melee attack, you may make a melee ATR attack against the attacking creature with Light+ATR fire attack power targeting REFL or WILL.
         range: Melee
         target: A+E, Single target
         type: Active
@@ -649,9 +651,9 @@ classes:
       - level: 3
         name: Thunder Jump
         apCost: 2
-        otherCost: 1 REFL or WILL
+        otherCost: 2 REFL or WILL
         flavourText: Leap away with a thunderous blast.
-        description: Make a versatile MOD attack against all creatures within 10ft with Medium lightning attack power targeting REFL. Then you may jump to a tile within 30ft.
+        description: Make a versatile ATR attack against all creatures within 10ft with Medium lightning attack power targeting REFL. Then you may jump to a tile within 30ft.
         range: 10ft
         target: A+E, All within range (AoE)
         type: Active
@@ -659,9 +661,9 @@ classes:
       - level: 3
         name: Stalactite
         apCost: 2
-        otherCost: 1 FORT or WILL
+        otherCost: 2 FORT or WILL
         flavourText: Drop a large spiked rock on your foe.
-        description: Make a versatile MOD attack against a creature within 50ft with Medium+ATR attack power targeting FORT or REFL. If the creature is prone or immobilised, gain additional Medium attack power.
+        description: Make a versatile ATR attack against a creature within 50ft with Medium+ATR attack power targeting FORT or REFL. If the creature is prone or immobilised, gain additional Medium attack power.
         range: 50ft
         target: A+E, Single target
         type: Active
@@ -743,9 +745,9 @@ classes:
       - level: 1
         name: Toll The Dead
         apCost: "-"
-        otherCost: 1 WILL and your reaction
+        otherCost: 2 WILL and your reaction
         flavourText: Exploit the last of a creature's essence to maim your foe.
-        description: When you reduce a creature within 100ft to 0 HP, you may spend 1 WILL and your reaction to make a versatile SPI attack against another creature within 15ft of the initial target with Medium+ATR soul attack power. It must specifically be you and your damage that reduces the creature to 0 HP.
+        description: When you reduce a creature within 100ft to 0 HP, you may make a versatile SPI attack against another creature within 15ft of the initial target with Medium+ATR soul attack power. It must specifically be you and your damage that reduces the creature to 0 HP.
         range: 100ft
         target: A+E, Single target within 15ft
         type: Active
@@ -773,7 +775,7 @@ classes:
       - level: 2
         name: Burst of Essence
         apCost: 2
-        otherCost: 2 FORT or WILL - Deadly Escalation
+        otherCost: 3 FORT or WILL - Deadly Escalation
         flavourText: Explode with restorative or destructive energy.
         description: "Select any number of creatures within 10ft and then either: heal each creature for SPI HP (includes self); or remove the Deadly Escalation cost and make a versatile SPI attack against each creature with Light+ATR soul attack power targeting FORT or WILL (excludes self). You cannot both heal and deal damage with one use of this ability."
         range: 10ft
@@ -793,23 +795,23 @@ classes:
       - level: 3
         name: Don't Die On Me!
         apCost: "-"
-        otherCost: 1 REFL or 1 WILL
+        otherCost: 2 REFL or WILL + Reaction
         flavourText: Save an ally from death at the last possible moment.
-        description: When a creature within 25ft suffers damage that would reduce it to 0HP, you can have it reduced to 1HP instead and it becomes unconscious. The creature can only be woken up by another creature using the help action for 1 minute. On your next turn you start with 1 fewer AP.
-        range: 25ft
+        description: When a creature within 50ft gains the dying condition or suffers damage that would reduce it to 0HP, you can remove the dying condition, have it reduced to 1HP instead, and it becomes unconscious. 
+        range: 50ft
         target: A+E, Single target
         type: Active
         tags: [heal, reactive]
       - level: 3
         name: Tormented Soul
         apCost: 1
-        otherCost: 2 WILL
+        otherCost: 3 WILL
         flavourText: Your foe will destroy itself by harming others.
         description: Select a creature within 100ft and mark it. Half of all damage that this creature deals to other creatures is also dealt to themselves. Target may resist the mark and the damage effect with WILL. Cannot be cast on a creature already under the effect of this ability.
         range: 100ft
         target: A+E, Single target
         type: Active
-        tags: [debuff]
+        tags: [debuff] 
       - level: 3
         name: Blessed Aura
         apCost: 1
@@ -874,7 +876,7 @@ classes:
         target: All, Single target
         type: Passive
         tags: [defensive, support]
-      - level: 1
+      - level: 1 
         name: Spectral Ally
         apCost: 1
         otherCost: 1 WILL
@@ -1062,7 +1064,7 @@ classes:
       - level: 1
         name: Panic Attack
         apCost: 2
-        otherCost: 1 REFL or WILL
+        otherCost: 2 REFL or WILL
         flavourText: Trigger a creature to lose control and strike wildly.
         description: Select a creature within 100ft, this creature must spend its reaction to attack the closest creature using a regular attack without moving. If multiple creatures are the same distance the target is selected randomly. Target may resist being forced to make the attack with FORT or WILL.
         range: 100ft
@@ -1082,7 +1084,7 @@ classes:
       - level: 2
         name: Cruel Joke
         apCost: 2
-        otherCost: 3 WILL
+        otherCost: 4 WILL
         flavourText: Make a joke that cuts so deep it hurts.
         description: "Make a versatile INT attack against a creature within 100ft, with Heavy+ATR psychic attack power targeting WILL. Double the attack power of this attack if the creature has any of the following conditions: charmed, dominated, taunted, frightened, feeble or silenced. The creature is then also taunted by you. Target may resist the taunt with WILL."
         range: 100ft
@@ -1092,7 +1094,7 @@ classes:
       - level: 2
         name: Silence!
         apCost: 0
-        otherCost: 1 WILL
+        otherCost: 2 WILL
         flavourText: Mute yourself and another in an instant.
         description: Select a creature within 100ft and silence them and yourself. Target may resist the silence with WILL - you must both resist the condition separately. If you are silenced by this ability the other creature suffers 1 psychic damage.
         range: 100ft
@@ -1102,7 +1104,7 @@ classes:
       - level: 2
         name: Mirror Image
         apCost: 1
-        otherCost: 1 REFL or WILL
+        otherCost: 2 REFL or WILL
         flavourText: Conjure an illusion of yourself that animates as if real.
         description: Select a tile within 100ft and summon an illusion of yourself there. The illusion has 2 HP, no energy, is unaffected by all conditions, and doesn't have a turn. All enemies within 10ft of the illusion are taunted. The taunt ends if the illusion is destroyed. Target may resist the taunt with REFL or WILL.
         range: 100ft
@@ -1124,7 +1126,7 @@ classes:
         apCost: 1
         otherCost: 1 REFL or WILL
         flavourText: Overstimulate foe's five senses with white noise, causing them to sense nothing.
-        description: Select a creature within 100ft, they become blind and deafened. Target may resist the bilnd with REFL or WILL.
+        description: Select a creature within 100ft, they become blind and deafened. Target may resist the blind with REFL or WILL.
         range: 100ft
         target: A+E, Single target
         type: Active

--- a/public/core_abilities.yaml
+++ b/public/core_abilities.yaml
@@ -43,13 +43,13 @@ core_abilities:
 
   - level: "Core"
     name: "Inspect Creature"
-    description: "Have the GM roughly describe a creature’s strengths and weaknesses - this may require an INT+PER check (GM’s discretion). This is an opportunity for the GM to give clues to the players as to what might be a good strategy to take down the enemies and what abilities they might have. Without a skill check, a player can ask the GM to describe the creature’s resistance points as “exposed”/“vulnerable” if they have 0 resistance points of that type, “weak” if they have 1-3 points, and “strong”/“capable” if they have 4+ points. This is a key part of making sure your abilities have a good chance of taking effect on your enemies."
+    description: "Have the GM roughly describe a creature’s strengths and weaknesses - this may require an PER check (GM’s discretion). This is an opportunity for the GM to give clues to the players as to what might be a good strategy to take down the enemies and what abilities they might have. Without a skill check, a player can ask the GM to describe the creature’s resistance points as “exposed”/“vulnerable” if they have 0 resistance points of that type, “weak” if they have 1-3 points, and “strong”/“capable” if they have 4+ points. This is a key part of making sure your abilities have a good chance of taking effect on your enemies."
     target: "E"
     apCost: 0
 
   - level: "Core"
     name: "Hide"
-    description: "Make a DEX+DEX stealth check to become hidden. Any creature that cannot see you as you use this action is no longer aware of where you are if you roll higher than their passive perception. Most creatures still have object permanence so they may come looking for you using a perception check. If they roll higher than your stealth check or have direct line of sight to you, you are revealed."
+    description: "Make a DEX stealth check to become hidden. Any creature that cannot see you as you use this action is no longer aware of where you are if you roll higher than their passive perception. Most creatures still have object permanence so they may come looking for you using a perception check. If they roll higher than your stealth check or have direct line of sight to you, you are revealed."
     target: "S"
     apCost: 2
 

--- a/public/main_rules.yaml
+++ b/public/main_rules.yaml
@@ -326,7 +326,7 @@ sections:
       - id: dazed
         title: Dazed
         body: >-
-          The creature starts its next turn with 1AP fewer and cannot use reactions while dazed. If the creature is dazed during its turn it immediately spends up to 1AP. If it now has 0 AP remaining its turn immediately ends, otherwise it may continue to act. In all cases the stun still lasts until the start of the creature's turn that was the source of the daze as normal. If a creature that is dazed becomes dazed again, the most recent daze is upgraded to a stun instead.
+          The creature starts its next turn with 1AP fewer and cannot use reactions while dazed. If the creature is dazed during its turn it immediately spends up to 1AP. If it now has 0 AP remaining its turn immediately ends, otherwise it may continue to act. In all cases the daze still lasts until the start of the creature's turn that was the source of the daze as normal. If a creature that is dazed becomes dazed again, the most recent daze is upgraded to a stun instead.
       
       - id: stunned
         title: Stunned

--- a/public/main_rules.yaml
+++ b/public/main_rules.yaml
@@ -14,26 +14,28 @@ sections:
       - id: dice-system
         title: Core Dice System
         body: >-
-          Arcus uses a d6 dice pool system. Always 3d6 plus some number of additional dice. Every 5 or 6 rolled counts as 1 success. The three types of dice rolls in Arcus are Challenge, Attack, and Resistance.
+          Arcus uses a d6 dice pool system. Roll a number of d6, commonly determined by attributes or energy, every 5 or 6 rolled counts as 1 success. The three types of dice rolls in Arcus are Challenge, Attack, and Resistance.
         children:
           - id: challenge-roll
             title: Challenge Roll
-            summary: "A roll to resolve a challenging task. 3d6 plus 2 modifiers."
+            summary: "A roll to resolve a challenging task. 3d6 plus d6 equal to an attribute."
             body: 
-              - Whenever a player or creature attempts to do something that is challenging (not trivial or impossible), the GM will ask them to roll a challenge roll. The number of dice rolled will always be 3d6 plus additional d6 equal to 2 attributes added together. Every 5 or 6 counts as 1 success. The GM will secretly decide a number of successes required (SR) to succeed, rolling a number successes equal to or greater than the SR succeeds.
-              - The 2 attributes required for the roll are decided by the GM, and they may both be the same attribute. Additional dice may be added to the roll based on skills, advantages etc. Similarly, dice may be removed from the roll.
+              - Whenever a player or creature attempts to do something that is challenging (not trivial or impossible), the GM will ask them to roll a challenge roll. The number of dice rolled will always be 3d6 plus additional d6 equal to an attribute. Every 5 or 6 counts as 1 success. The GM will secretly decide a number of successes required (SR) to succeed, rolling a number successes equal to or greater than the SR succeeds.
+              - The attribute required for the roll is decided by the GM. Additional dice may be added to the roll based on skills, advantages etc. Similarly, dice may be removed from the roll.
           - id: attack-roll
             title: Attack Roll
-            summary: "A roll to resolve an attack and deal damage. Weapon power plus 2 modifiers."
+            summary: "A roll to resolve an attack and deal damage per success. Select energy type to target. d6 equal to attack power."
             body: 
-              - Whenever a player or creature attempts an attack, they will roll d6 equal to the attack power of the attack. The attack power will depend on the weapon or attack used, but will most commonly be Light, Medium, or Heavy (3, 6, or 9 d6) plus additional d6 equal to 2 attributes added together. Every success (5 or 6 rolled) counts as 1 damage dealt to the target of the attack.
-              - The weapon or attack type will decide what attributes are used for the roll. Additional dice may be added to the roll based on skills, advantages etc. Similarly, dice may be removed from the roll.
+              - "To resolve an attack against a target, the attacker must first select an energy type to attack: FORT, REFL, or WILL. This determines which energy the target will lose when the attack deals damage."
+              - Attack power determines how many d6 the attacker will roll. The attack power will depend on the weapon or attack used, which will most commonly be Light, Medium, or Heavy (3, 6, or 9 d6) plus additional d6 equal to an attribute. Every success (5 or 6 rolled) counts as 1 damage dealt to the target of the attack.
+              - The weapon or attack type will determine what attribute is used for the roll. Additional dice may be added to the roll based on skills, advantages etc. Similarly, dice may be removed from the roll.
+              - By default attacks may select any of the three energy types. Some attacks are restricted in which energy they can attack. Players being targeted by attacks may select which energy they lose when damage is dealt - only one energy type may be selected.  
           - id: resistance-roll
             title: Resistance Roll
-            summary: "A roll to resist an incoming negative effect. 3d6 plus one energy type."
+            summary: "A roll to resist an incoming negative effect. d6 equal to energy remaining in one type."
             body:
-              - Whenever a player or creature is inflicted with a negative effect they may roll 3d6 plus additional d6 equal to the number of energy points they have remaining in one of the energy types required. Only 1 success is needed to successfully resist the incoming effect.
-              - The energy type required is determined by the source of the effect, usually an ability description. If there are multiple energy types, the player will always get to decide which energy type they use to resist. If a player inflicts a creature with a negative condition, the player gets to choose which energy type the creature must use to attempt to resist.
+              - Whenever a player or creature is inflicted with a negative effect they may roll d6 equal to the number of energy points they have remaining in one of the energy types required. Only 1 success is needed to successfully resist the incoming effect.
+              - The energy type required is determined by the source of the effect, usually an ability description. If there are multiple energy types, the player will always get to select which energy type they use to resist. If a player inflicts a creature with a negative condition, the player gets to select which energy type the creature must use to attempt to resist.
       
       - id: advantage-disadvantage
         title: Advantage and Disadvantage (Adv/DisAdv)
@@ -77,33 +79,32 @@ sections:
         body:
           - "Characters have 6 attributes: Strength (STR), Constitution (CON), Dexterity (DEX), Perception (PER), Intelligence (INT), and Spirit (SPI)."
                     
-          - At level 1, characters have 0 in each attribute and 10 points to assign in any combination of attributes they choose. Players may reduce an attribute to -1 so long as it does not result in a negative energy total. On every even level (2, 4, 6 etc.) characters gain 1 additional attribute point to assign in any attribute they choose.
-          
-          - The value of an attribute is equal to the number of additional dice rolled when making a roll that includes that attribute type. 2 attributes will be added to almost all rolls. The value will also increase energy in the corresponding type.
+          - At level 1, characters have 0 in each attribute and 18 points to assign in any combination of attributes they choose. To increase an attribute from 5 to 6 (and above) it costs 2 points to increase the attribute by 1. Characters may reduce an attribute to -1. However, after assigning attributes and calculating energy, characters must have a minimum value of 1 in each energy type. On every even level (2, 4, 6 etc.) characters gain 2 additional points to assign in any attribute(s) they choose.
+
         children: 
           - id: strength 
             title: Strength (STR)
-            body: A character's physical strength and brute force. In addition to strength based rolls, strength value (STR) can be used for all melee weapons, and to reduce incoming damage with a shield.
+            body: A character's physical strength and brute force. In addition to strength based rolls, the strength attribute (STR) can be used for all melee weapons, and to reduce incoming damage with a shield.
           
           - id: constitution 
             title: Constitution (CON)
-            body: A combination of the character's overall health and endurance. In addition to constitution based rolls, characters will also have hit points (HP) equal to 6 plus 3 times their CON attribute.
+            body: A combination of the character's overall health and endurance. In addition to constitution based rolls, characters will also have hit points (HP) equal to 5 plus 2 times their constitution attribute (CON).
 
           - id: dexterity 
             title: Dexterity (DEX)
-            body: A character's hand-eye coordination, balance, and overall grace. In addition to dexterity based rolls, dexterity value (DEX) can be used for light and medium melee weapons, and thrown weapon attacks.
+            body: A character's hand-eye coordination, balance, and overall grace. In addition to dexterity based rolls, the dexterity attribute (DEX) can be used for light and medium melee weapons, and thrown weapon attacks.
 
           - id: perception 
             title: Perception (PER)
-            body: A character's senses/awareness, ability to aim, and their instinctive ability to pick up on details. In addition to perception based rolls, perception value (PER) is used for ranged weapons and sometimes initiative - how early a creature acts in combat.
+            body: A character's senses/awareness, ability to aim, and their instinctive ability to pick up on details. In addition to perception based rolls, the perception attribute (PER) is used for ranged weapons and sometimes initiative - how early a creature acts in combat.
 
           - id: intelligence 
             title: Intelligence (INT)
-            body: a character's logic and reasoning capabilities as well as memory and knowledge. In addition to intelligence based rolls, intelligence value (INT) is used for some abilities from classes such as Arcane and Psionic.
+            body: a character's logic and reasoning capabilities as well as memory and knowledge. In addition to intelligence based rolls, the intelligence attribute (INT) is used for some abilities from classes such as Arcane and Psionic.
 
           - id: spirit 
             title: Spirit (SPI)
-            body: A character's mental resolve, confidence and creativity. In addition to spirit based rolls, spirit modifier (SPI) is used for some abilities from some classes such as Mortality and Elemental.
+            body: A character's mental resolve, confidence and creativity. In addition to spirit based rolls, the spirit attribute (SPI) is used for some abilities from some classes such as Mortality and Elemental.
       
       - id: energy
         title: Energy
@@ -129,19 +130,18 @@ sections:
           
           - id: resist-energy
             title: Energy For Resisting Conditions
-            summary: "If the creature has energy remaining, make a resist roll: 3d6 + a number of d6 equal to it's remaining energy in that type. 1 success to resist and negate the incoming negative effect."
+            summary: "Make a resist roll: roll a number of d6 equal to the remaining energy in that type. 1 success to resist and negate the incoming negative effect."
             body:
-              - "When a creature is inflicted with a negative condition, if the creature has 1 or more energy of the required type to resist the effect it may make a resist roll: 3d6 + a number of d6 equal to it's remaining energy in that type. The incoming negative effect is resisted and therefore completely negated if the creature rolls at least 1 success. However, some effects may require more successes to resist. If the creature has 0 energy in the required type it cannot attempt a resist roll."
+              - Whenever a player or creature is inflicted with a negative effect they may roll d6 equal to the number of energy points they have remaining in one of the energy types required. Only 1 success is needed to successfully resist the incoming effect.
+              - The energy type required is determined by the source of the effect, usually an ability description. If there are multiple energy types, the player will always get to select which energy type they use to resist. If a player inflicts a creature with a negative condition, the player gets to select which energy type the creature must use to attempt to resist.
           
       - id: hit-points
         title: Hit Points
         summary: The amount of damage a creature can suffer before it dies. 
         body:
-          - At level 1 characters will have hit points (HP) equal to 6 plus 3 times their CON attribute. 2 CON would lead to 6 + 3*2 = 12 HP. HP can be fully regained on a long rest.
+          - At level 1 characters will have hit points (HP) equal to 5 plus 2 times their CON attribute. 2 CON would lead to 5 + 2*2 = 9 HP. HP can be fully regained on a long rest.
 
-          - When a character's HP would reduced to 0, if it has any energy remaining (ignoring armour and shield energy) it instead falls unconscious and it's HP is set to 1 and it gains the Dying condition. If the creature has no energy remaining (ignoring armour and shield energy) is dies.
-
-          - When any creature that is not a character is reduced to 0 HP it dies - unless the damage dealt is classed as non-lethal, in which case it falls unconscious and it's HP is set to 1.
+          - See the Unconscious and Death section to learn about what happens when HP is reduced to 0.
       
       - id: skills
         title: Skills
@@ -182,9 +182,9 @@ sections:
       - id: shields
         title: Shields
         body: 
-          - Equipping a shield unlocks the Raise Shield core action that allows the wielder to gain 1 shield energy in each energy type for 0 AP. 
+          - Equipping a shield unlocks the Raise Shield core action that allows the wielder to gain 1 shield energy in each energy type for 0 AP, or gain 2 shield in each energy type for 1 AP. 
 
-          - Shields require at least 2 STR to equip.
+          - Shields require at least 4 STR to equip.
 
   - id: combat
     title: Combat
@@ -193,7 +193,7 @@ sections:
       - id: combat-basics
         title: Combat Basics
         body: 
-          - Combat starts when a creature takes an hostile action against a creature which leads to the other side wanting to take hostile actions against the initiator.
+          - Combat starts when a creature resolves a hostile action against a creature which leads to the other side wanting to take hostile actions against the initiator.
 
           - Combat takes place on a hex or square grid. Each space on the grid is referred to as a tile and is 5ft across. Whenever a creature moves 5ft it moves 1 tile in any direction, including diagonals.
 
@@ -206,11 +206,11 @@ sections:
         body:
           - Initiative determines the order in which turns are taken in combat. 
           
-          - Initiator of the combat acts first and then proceeds clockwise around the table. If there is no clear initiator then players and creatures may each make a PER+PER roll to decide who acts first. 
+          - Initiator of the combat acts first and then proceeds clockwise around the table. If there is no clear initiator then players and creatures may each make a PER roll to decide who acts first. 
           
           - The GM may place 1 group of enemies between each player, if there are too many enemy groups, the remaining groups are placed after the last player to act. The initiative remains static for the rest of the fight.
           
-          - "Alternative Initiative Ruling: Alternating initiative between PCs and GM where 1 creature or player from each side takes a turn and then it is passed back to the other side. The GM decides who is going first based on who initiated the combat, if there is no clear initiator then PCs roll for REFL and if one of them gets the SR determined by the GM for this combat, the PCs may go first. If it is the PCs turn they may decide amongst them who will take that turn, after that player's turn is complete they cannot take another turn this round. Then it is the GMs turn and they will choose which creature will take their turn, and after that it is passed back to the PCs to choose who will go next, and so on."
+          - "Alternative Initiative Ruling: Alternating initiative between PCs and GM where 1 creature or player from each side takes a turn and then it is passed back to the other side. The GM decides who is going first based on who initiated the combat, if there is no clear initiator then PCs roll for PER and if one of them gets the SR determined by the GM for this combat, the PCs may go first. If it is the PCs turn they may decide amongst them who will take that turn, after that player's turn is complete they cannot take another turn this round. Then it is the GMs turn and they will choose which creature will take their turn, and after that it is passed back to the PCs to choose who will go next, and so on."
       
       - id: action-points
         title: Action Points
@@ -229,7 +229,7 @@ sections:
       - id: energy-combat
         title: Energy in Combat
         body: 
-          - At the start of each character's turn, they will regain up to 2 energy in one or two energy types, up to their maximum.
+          - At the start of each character's turn, they may regain one energy, up to their maximum.
           
           - "All attacks will target one of the three energy types: FORT, REFL, or WILL. For example: think of this as using a sword to attack the torso (FORT), the limbs (REFL), or the head (WILL). The attacking characters are encouraged to describe how they formulate their attack to target the chosen energy type, to add to the thematics of combat."
           
@@ -238,7 +238,7 @@ sections:
       - id: attacks
         title: Attacks
         body: >-
-          When attacking, a character will select one of the energy types to target and roll a number of d6 equal to the attack power (3, 6, or 9 for Light, Medium, or Heavy respectively) plus a number of d6 equal to 2 other attributes required for the attack (most commonly the same attribute twice). Each success (hit) will deal 1 damage to the target energy type. If the damage is greater than the number of energy points then the damage will carry over into the target's HP.
+          When attacking, a character will select one of the energy types to target and roll a number of d6 equal to the attack power (3, 6, or 9 for Light, Medium, or Heavy respectively) plus a number of d6 equal to one other attribute required for the attack. Each success (hit) will deal 1 damage to the target energy type. If the damage is greater than the number of energy points then the damage will carry over into the target's HP.
       
       - id: resistance-vulnerability
         title: Resistance and Vulnerability
@@ -255,7 +255,7 @@ sections:
       - id: condition-mechanics
         title: Condition Mechanics
         body: >-
-          Conditions are continual effects that will always last until the start of the source's next turn unless stated otherwise. Anything that applies a condition or immediate effect will also state which energy types must be used to resist it, such as: FORT to resist the push, or FORT or REFL (source of the condition decides which one the target must use) to resist being knocked prone. The target must roll 3d6 plus a number of d6 equal to their remaining points in that energy type (including shield, armour and energy) and require only one success to avoid the condition or effect. Therefore, you should generally aim to get an enemy's energy to 0 before attempting to apply conditions.
+          Conditions are a type of negative effect. Conditions are continual effects that will always last until the start of the source's next turn unless stated otherwise. See the Resistance Roll section to learn how negative effects are applied.
       
       - id: abilities
         title: Abilities
@@ -265,9 +265,9 @@ sections:
       - id: unconscious-death
         title: Unconscious and Death
         body: >-
-          A character will fall unconscious when it is reduced to 0HP. Other creatures will die when they reach 0HP (unless the attacker was trying to knock them unconscious). Characters that are unconscious cannot regain energy at the start of each turn. They will remain stable and only lose energy if they suffer any damage of any type.
-          
-          A character will die when it has 0HP and also 0 points in all 3 energy types.
+          - When a character's HP would reduced to 0, if it has any energy remaining (ignoring armour and shield energy) it instead falls unconscious and it's HP is set to 1 and it gains the Dying condition. If the creature has no energy remaining (ignoring armour and shield energy) it dies.
+
+          - When any creature that is not a character is reduced to 0 HP it dies - unless the damage dealt is classed as non-lethal, in which case it falls unconscious and it's HP is set to 1.
 
   - id: conditions
     title: Conditions

--- a/public/main_rules.yaml
+++ b/public/main_rules.yaml
@@ -229,7 +229,7 @@ sections:
       - id: energy-combat
         title: Energy in Combat
         body: 
-          - At the start of each character's turn, they may regain one energy, up to their maximum.
+          - At the start of each character's turn they may regain one energy in a type of their choice, up to their maximum.
           
           - "All attacks will target one of the three energy types: FORT, REFL, or WILL. For example: think of this as using a sword to attack the torso (FORT), the limbs (REFL), or the head (WILL). The attacking characters are encouraged to describe how they formulate their attack to target the chosen energy type, to add to the thematics of combat."
           

--- a/public/main_rules.yaml
+++ b/public/main_rules.yaml
@@ -356,7 +356,7 @@ sections:
       - id: poisoned
         title: Poisoned
         body: >-
-          The creature cannot heal or regain health or regain any energy type. This condition is removed by healing.
+          The creature cannot heal or regain health or regain any energy type. This condition is removed by healing. When an instance of healing removes the poisoned condition, no health is regained.
       
       - id: bleeding
         title: Bleeding


### PR DESCRIPTION
All rolls now add one attribute instead of two.

All attributes have have been increased so that they normally scale from 1-10 instead of 1-5.

Energy has therefore increased. All energy costs of abilities have been tweaked along with some abilities changing or being simplified to suit their new adjusted cost.